### PR TITLE
Add compatible and artifacts options to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    ignore:
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -31,6 +30,15 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
+    groups:
+      compatible:
+        update-types:
+          - "minor"
+          - "patch"
+      artifacts:
+        patterns:
+          - "actions/*-artifact"
+
 
   - package-ecosystem: "cargo"
     directory: "/"


### PR DESCRIPTION
This PR updates the `dependabot.yml` file by:

- removing the empty `ignore` option
- adding `compatible` and `artifacts option to `github-actions`

solves #7 