### PR TITLE
Add option to choose which timestamp to use for resample

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ use frequenz_resampling::{Resampler, ResamplingFunction, Sample};
 
 let start = DateTime::from_timestamp(0, 0).unwrap();
 let mut resampler: Resampler<f64, TestSample> =
-    Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start);
+    Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start, false);
 let step = TimeDelta::seconds(1);
 let data = vec![
     TestSample::new(start, Some(1.0)),
@@ -61,7 +61,13 @@ from frequenz.resampling import Resampler, ResamplingFunction
 
 start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
 step = dt.timedelta(seconds=1)
-resampler = Resampler(dt.timedelta(seconds=5), ResamplingFunction.Average, 1, start)
+resampler = Resampler(
+    dt.timedelta(seconds=5),
+    ResamplingFunction.Average,
+    max_age_in_intervals=1,
+    start=start,
+    first_timestamp=False,
+)
 
 for i in range(10):
     resampler.push_sample(timestamp=start + i * step, value=i + 1)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,5 +10,8 @@
 - Adds python bindings for the resampler.
 - Adapts the ResamplingFunction Python interface to Python Enums.
 - Makes custom resampling function Sync.
+- Adds a `first_timestamp` parameter to the resampler to control whether the
+  resampled timestamp should be the first timestamp in the buffer or the last
+  timestamp in the buffer.
 
 ## Bug Fixes

--- a/frequenz/resampling/_rust_backend.pyi
+++ b/frequenz/resampling/_rust_backend.pyi
@@ -61,6 +61,7 @@ class Resampler:
         *,
         max_age_in_intervals: int,
         start: datetime,
+        first_timestamp: bool = True,
     ):
         """
         Initializes a new Resampler object.
@@ -70,6 +71,9 @@ class Resampler:
             resampling_function: The resampling function.
             max_age_in_intervals: The maximum age of a sample in intervals.
             start: The start time of the resampling.
+            first_timestamp: Whether the resampled timestamp should be the first
+                timestamp in the buffer or the last timestamp in the buffer.
+                Defaults to `True`.
         """
 
     def push_sample(self, *, timestamp: datetime, value: Optional[float]) -> None:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,20 +44,20 @@ impl Sample for TestSample {
 
 let start = DateTime::from_timestamp(0, 0).unwrap();
 let mut resampler: Resampler<f64, TestSample> =
-    Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start);
+    Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start, false);
 
 let step = TimeDelta::seconds(1);
 let data = vec![
-    TestSample::new(start, Some(1.0)),
-    TestSample::new(start + step, Some(2.0)),
-    TestSample::new(start + step * 2, Some(3.0)),
-    TestSample::new(start + step * 3, Some(4.0)),
-    TestSample::new(start + step * 4, Some(5.0)),
-    TestSample::new(start + step * 5, Some(6.0)),
-    TestSample::new(start + step * 6, Some(7.0)),
-    TestSample::new(start + step * 7, Some(8.0)),
-    TestSample::new(start + step * 8, Some(9.0)),
-    TestSample::new(start + step * 9, Some(10.0)),
+    TestSample::new(start + step, Some(1.0)),
+    TestSample::new(start + step * 2, Some(2.0)),
+    TestSample::new(start + step * 3, Some(3.0)),
+    TestSample::new(start + step * 4, Some(4.0)),
+    TestSample::new(start + step * 5, Some(5.0)),
+    TestSample::new(start + step * 6, Some(6.0)),
+    TestSample::new(start + step * 7, Some(7.0)),
+    TestSample::new(start + step * 8, Some(8.0)),
+    TestSample::new(start + step * 9, Some(9.0)),
+    TestSample::new(start + step * 10, Some(10.0)),
 ];
 
 resampler.extend(data);

--- a/src/python.rs
+++ b/src/python.rs
@@ -154,12 +154,13 @@ struct ResamplerF32 {
 #[pymethods]
 impl ResamplerF32 {
     #[new]
-    #[pyo3(signature = (interval, resampling_function, *, max_age_in_intervals, start))]
+    #[pyo3(signature = (interval, resampling_function, *, max_age_in_intervals, start, first_timestamp=true))]
     fn new(
         interval: TimeDelta,
         resampling_function: ResamplingFunctionF32,
         max_age_in_intervals: i32,
         start: DateTime<Utc>,
+        first_timestamp: bool,
     ) -> Self {
         Self {
             inner: Resampler::new(
@@ -167,6 +168,7 @@ impl ResamplerF32 {
                 resampling_function.into(),
                 max_age_in_intervals,
                 start,
+                first_timestamp,
             ),
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -34,19 +34,19 @@ fn test_resampling(
 ) {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start);
+        Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
     let step = TimeDelta::seconds(1);
     let data = vec![
-        TestSample::new(start, Some(1.0)),
-        TestSample::new(start + step, Some(2.0)),
-        TestSample::new(start + step * 2, Some(3.0)),
-        TestSample::new(start + step * 3, Some(4.0)),
-        TestSample::new(start + step * 4, Some(5.0)),
-        TestSample::new(start + step * 5, Some(6.0)),
-        TestSample::new(start + step * 6, Some(7.0)),
-        TestSample::new(start + step * 7, Some(8.0)),
-        TestSample::new(start + step * 8, Some(9.0)),
-        TestSample::new(start + step * 9, Some(10.0)),
+        TestSample::new(start + step, Some(1.0)),
+        TestSample::new(start + step * 2, Some(2.0)),
+        TestSample::new(start + step * 3, Some(3.0)),
+        TestSample::new(start + step * 4, Some(4.0)),
+        TestSample::new(start + step * 5, Some(5.0)),
+        TestSample::new(start + step * 6, Some(6.0)),
+        TestSample::new(start + step * 7, Some(7.0)),
+        TestSample::new(start + step * 8, Some(8.0)),
+        TestSample::new(start + step * 9, Some(9.0)),
+        TestSample::new(start + step * 10, Some(10.0)),
     ];
 
     resampler.extend(data);
@@ -137,25 +137,30 @@ fn test_resampling_custom() {
 #[test]
 fn test_resampling_with_max_age() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 2, start);
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        2,
+        start,
+        false,
+    );
     let step = TimeDelta::seconds(1);
     let data = vec![
-        TestSample::new(start, Some(1.0)),
-        TestSample::new(start + step, Some(2.0)),
-        TestSample::new(start + step * 2, Some(3.0)),
-        TestSample::new(start + step * 3, Some(4.0)),
-        TestSample::new(start + step * 4, Some(5.0)),
-        TestSample::new(start + step * 5, Some(6.0)),
-        TestSample::new(start + step * 6, Some(7.0)),
-        TestSample::new(start + step * 7, Some(8.0)),
-        TestSample::new(start + step * 8, Some(9.0)),
-        TestSample::new(start + step * 9, Some(10.0)),
-        TestSample::new(start + step * 10, Some(11.0)),
-        TestSample::new(start + step * 11, Some(12.0)),
-        TestSample::new(start + step * 12, Some(13.0)),
-        TestSample::new(start + step * 13, Some(14.0)),
-        TestSample::new(start + step * 14, Some(15.0)),
+        TestSample::new(start + step, Some(1.0)),
+        TestSample::new(start + step * 2, Some(2.0)),
+        TestSample::new(start + step * 3, Some(3.0)),
+        TestSample::new(start + step * 4, Some(4.0)),
+        TestSample::new(start + step * 5, Some(5.0)),
+        TestSample::new(start + step * 6, Some(6.0)),
+        TestSample::new(start + step * 7, Some(7.0)),
+        TestSample::new(start + step * 8, Some(8.0)),
+        TestSample::new(start + step * 9, Some(9.0)),
+        TestSample::new(start + step * 10, Some(10.0)),
+        TestSample::new(start + step * 11, Some(11.0)),
+        TestSample::new(start + step * 12, Some(12.0)),
+        TestSample::new(start + step * 13, Some(13.0)),
+        TestSample::new(start + step * 14, Some(14.0)),
+        TestSample::new(start + step * 15, Some(15.0)),
     ];
 
     resampler.extend(data);
@@ -173,8 +178,13 @@ fn test_resampling_with_max_age() {
 #[test]
 fn test_resampling_with_zero_max_age() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 0, start);
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        0,
+        start,
+        false,
+    );
     let step = TimeDelta::seconds(1);
     let data = vec![
         TestSample::new(start, Some(1.0)),
@@ -209,25 +219,30 @@ fn test_resampling_with_zero_max_age() {
 #[test]
 fn test_resampling_with_max_age_older() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 3, start);
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        3,
+        start,
+        false,
+    );
     let step = TimeDelta::seconds(1);
     let data = vec![
-        TestSample::new(start, Some(1.0)),
-        TestSample::new(start + step, Some(2.0)),
-        TestSample::new(start + step * 2, Some(3.0)),
-        TestSample::new(start + step * 3, Some(4.0)),
-        TestSample::new(start + step * 4, Some(5.0)),
-        TestSample::new(start + step * 5, Some(6.0)),
-        TestSample::new(start + step * 6, Some(7.0)),
-        TestSample::new(start + step * 7, Some(8.0)),
-        TestSample::new(start + step * 8, Some(9.0)),
-        TestSample::new(start + step * 9, Some(10.0)),
-        TestSample::new(start + step * 10, Some(11.0)),
-        TestSample::new(start + step * 11, Some(12.0)),
-        TestSample::new(start + step * 12, Some(13.0)),
-        TestSample::new(start + step * 13, Some(14.0)),
-        TestSample::new(start + step * 14, Some(15.0)),
+        TestSample::new(start + step, Some(1.0)),
+        TestSample::new(start + step * 2, Some(2.0)),
+        TestSample::new(start + step * 3, Some(3.0)),
+        TestSample::new(start + step * 4, Some(4.0)),
+        TestSample::new(start + step * 5, Some(5.0)),
+        TestSample::new(start + step * 6, Some(6.0)),
+        TestSample::new(start + step * 7, Some(7.0)),
+        TestSample::new(start + step * 8, Some(8.0)),
+        TestSample::new(start + step * 9, Some(9.0)),
+        TestSample::new(start + step * 10, Some(10.0)),
+        TestSample::new(start + step * 11, Some(11.0)),
+        TestSample::new(start + step * 12, Some(12.0)),
+        TestSample::new(start + step * 13, Some(13.0)),
+        TestSample::new(start + step * 14, Some(14.0)),
+        TestSample::new(start + step * 15, Some(15.0)),
     ];
 
     resampler.extend(data);
@@ -245,27 +260,32 @@ fn test_resampling_with_max_age_older() {
 #[test]
 fn test_resampling_with_max_age_batch() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 2, start);
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        2,
+        start,
+        false,
+    );
     let step = TimeDelta::seconds(1);
     let data1 = vec![
-        TestSample::new(start, Some(1.0)),
-        TestSample::new(start + step, Some(2.0)),
-        TestSample::new(start + step * 2, Some(3.0)),
-        TestSample::new(start + step * 3, Some(4.0)),
-        TestSample::new(start + step * 4, Some(5.0)),
-        TestSample::new(start + step * 5, Some(6.0)),
-        TestSample::new(start + step * 6, Some(7.0)),
-        TestSample::new(start + step * 7, Some(8.0)),
-        TestSample::new(start + step * 8, Some(9.0)),
-        TestSample::new(start + step * 9, Some(10.0)),
+        TestSample::new(start + step * 1, Some(1.0)),
+        TestSample::new(start + step * 2, Some(2.0)),
+        TestSample::new(start + step * 3, Some(3.0)),
+        TestSample::new(start + step * 4, Some(4.0)),
+        TestSample::new(start + step * 5, Some(5.0)),
+        TestSample::new(start + step * 6, Some(6.0)),
+        TestSample::new(start + step * 7, Some(7.0)),
+        TestSample::new(start + step * 8, Some(8.0)),
+        TestSample::new(start + step * 9, Some(9.0)),
+        TestSample::new(start + step * 10, Some(10.0)),
     ];
     let data2 = vec![
-        TestSample::new(start + step * 10, Some(11.0)),
-        TestSample::new(start + step * 11, Some(12.0)),
-        TestSample::new(start + step * 12, Some(13.0)),
-        TestSample::new(start + step * 13, Some(14.0)),
-        TestSample::new(start + step * 14, Some(15.0)),
+        TestSample::new(start + step * 11, Some(11.0)),
+        TestSample::new(start + step * 12, Some(12.0)),
+        TestSample::new(start + step * 13, Some(13.0)),
+        TestSample::new(start + step * 14, Some(14.0)),
+        TestSample::new(start + step * 15, Some(15.0)),
     ];
 
     resampler.extend(data1);
@@ -292,16 +312,21 @@ fn test_resampling_with_max_age_batch() {
 #[test]
 fn test_resampling_with_gap() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start);
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        false,
+    );
     let step = TimeDelta::seconds(1);
     let data = vec![
-        TestSample::new(start, Some(1.0)),
-        TestSample::new(start + step, Some(2.0)),
-        TestSample::new(start + step * 3, Some(4.0)),
-        TestSample::new(start + step * 4, Some(5.0)),
-        TestSample::new(start + step * 16, Some(6.0)),
-        TestSample::new(start + step * 19, Some(10.0)),
+        TestSample::new(start + step, Some(1.0)),
+        TestSample::new(start + step * 2, Some(2.0)),
+        TestSample::new(start + step * 4, Some(4.0)),
+        TestSample::new(start + step * 5, Some(5.0)),
+        TestSample::new(start + step * 17, Some(6.0)),
+        TestSample::new(start + step * 20, Some(10.0)),
     ];
 
     resampler.extend(data);
@@ -320,8 +345,13 @@ fn test_resampling_with_gap() {
 #[test]
 fn test_resampling_with_slow_data() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(1), ResamplingFunction::Average, 2, start);
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(1),
+        ResamplingFunction::Average,
+        2,
+        start,
+        false,
+    );
     let offset = TimeDelta::milliseconds(500);
     let step = TimeDelta::seconds(2);
     let data = vec![
@@ -351,16 +381,21 @@ fn test_resampling_with_slow_data() {
 #[test]
 fn test_resampling_with_gap_early_end_date() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start);
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        false,
+    );
     let step = TimeDelta::seconds(1);
     let data = vec![
-        TestSample::new(start, Some(1.0)),
-        TestSample::new(start + step, Some(2.0)),
-        TestSample::new(start + step * 3, Some(4.0)),
-        TestSample::new(start + step * 4, Some(5.0)),
-        TestSample::new(start + step * 16, Some(6.0)),
-        TestSample::new(start + step * 19, Some(10.0)),
+        TestSample::new(start + step, Some(1.0)),
+        TestSample::new(start + step * 2, Some(2.0)),
+        TestSample::new(start + step * 4, Some(4.0)),
+        TestSample::new(start + step * 5, Some(5.0)),
+        TestSample::new(start + step * 17, Some(6.0)),
+        TestSample::new(start + step * 20, Some(10.0)),
     ];
 
     resampler.extend(data);
@@ -385,8 +420,13 @@ fn test_resampling_with_gap_early_end_date() {
 #[test]
 fn test_empty_buffer() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start);
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        false,
+    );
 
     let resampled = resampler.resample(start + TimeDelta::seconds(10));
     assert_eq!(
@@ -413,5 +453,41 @@ fn test_epoch_alignment() {
             Some(DateTime::from_timestamp(1, 0).unwrap())
         ),
         DateTime::from_timestamp(1, 0).unwrap()
+    );
+}
+
+#[test]
+fn test_is_right_of_buffer_edge() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        true,
+    );
+    let step = TimeDelta::seconds(1);
+    let data = vec![
+        TestSample::new(start, Some(1.0)),
+        TestSample::new(start + step * 1, Some(2.0)),
+        TestSample::new(start + step * 2, Some(3.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 5, Some(6.0)),
+        TestSample::new(start + step * 6, Some(7.0)),
+        TestSample::new(start + step * 7, Some(8.0)),
+        TestSample::new(start + step * 8, Some(9.0)),
+        TestSample::new(start + step * 9, Some(10.0)),
+    ];
+
+    resampler.extend(data);
+
+    let resampled = resampler.resample(start + step * 10);
+    assert_eq!(
+        resampled,
+        vec![
+            TestSample::new(DateTime::from_timestamp(0, 0).unwrap(), Some(3.0)),
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(8.0)),
+        ],
     );
 }

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -17,10 +17,11 @@ def test_resampler_resampling_function_average() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
+        first_timestamp=False,
     )
 
-    for i in range(10):
-        resampler.push_sample(timestamp=start + i * step, value=i + 1)
+    for i in range(1, 11):
+        resampler.push_sample(timestamp=start + i * step, value=i)
 
     expected = [
         (start + 5 * step, 3.0),
@@ -41,10 +42,11 @@ def test_resampler_resampling_function_sum() -> None:
         ResamplingFunction.Sum,
         max_age_in_intervals=1,
         start=start,
+        first_timestamp=False,
     )
 
-    for i in range(10):
-        resampler.push_sample(timestamp=start + i * step, value=i + 1)
+    for i in range(1, 11):
+        resampler.push_sample(timestamp=start + i * step, value=i)
 
     expected = [
         (start + 5 * step, 15.0),
@@ -65,10 +67,11 @@ def test_resampler_resampling_function_max() -> None:
         ResamplingFunction.Max,
         max_age_in_intervals=1,
         start=start,
+        first_timestamp=False,
     )
 
-    for i in range(10):
-        resampler.push_sample(timestamp=start + i * step, value=i + 1)
+    for i in range(1, 11):
+        resampler.push_sample(timestamp=start + i * step, value=i)
 
     expected = [
         (start + 5 * step, 5.0),
@@ -89,10 +92,11 @@ def test_resampler_resampling_function_min() -> None:
         ResamplingFunction.Min,
         max_age_in_intervals=1,
         start=start,
+        first_timestamp=False,
     )
 
-    for i in range(10):
-        resampler.push_sample(timestamp=start + i * step, value=i + 1)
+    for i in range(1, 11):
+        resampler.push_sample(timestamp=start + i * step, value=i)
 
     expected = [
         (start + 5 * step, 1.0),
@@ -113,10 +117,11 @@ def test_resampler_resampling_function_last() -> None:
         ResamplingFunction.Last,
         max_age_in_intervals=1,
         start=start,
+        first_timestamp=False,
     )
 
-    for i in range(10):
-        resampler.push_sample(timestamp=start + i * step, value=i + 1)
+    for i in range(1, 11):
+        resampler.push_sample(timestamp=start + i * step, value=i)
 
     expected = [
         (start + 5 * step, 5.0),
@@ -137,10 +142,11 @@ def test_resampler_resampling_function_count() -> None:
         ResamplingFunction.Count,
         max_age_in_intervals=1,
         start=start,
+        first_timestamp=False,
     )
 
-    for i in range(10):
-        resampler.push_sample(timestamp=start + i * step, value=i + 1)
+    for i in range(1, 11):
+        resampler.push_sample(timestamp=start + i * step, value=i)
 
     expected = [
         (start + 5 * step, 5.0),
@@ -161,9 +167,10 @@ def test_resampling_none() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
+        first_timestamp=False,
     )
 
-    for i in range(10):
+    for i in range(1, 11):
         resampler.push_sample(timestamp=start + i * step, value=None)
 
     expected = [
@@ -233,3 +240,53 @@ def test_resampling_function_init() -> None:
     assert ResamplingFunction(3) == ResamplingFunction.Min
     assert ResamplingFunction(4) == ResamplingFunction.Last
     assert ResamplingFunction(5) == ResamplingFunction.Count
+
+
+def test_resampler_first_timestamp() -> None:
+    """Test the resampler with the first timestamp."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=0.5)
+    resampler = Resampler(
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        max_age_in_intervals=1,
+        start=start,
+        first_timestamp=True,
+    )
+
+    for i in range(0, 20):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
+
+    expected = [
+        (start + 0 * step, 5.5),
+        (start + 10 * step, 15.5),
+    ]
+
+    resampled = resampler.resample(start + 20 * step)
+
+    assert resampled == expected
+
+
+def test_resampler_last_timestamp() -> None:
+    """Test the resampler with the last timestamp."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=0.5)
+    resampler = Resampler(
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        max_age_in_intervals=1,
+        start=start,
+        first_timestamp=False,
+    )
+
+    for i in range(1, 21):
+        resampler.push_sample(timestamp=start + i * step, value=i)
+
+    expected = [
+        (start + 10 * step, 5.5),
+        (start + 20 * step, 15.5),
+    ]
+
+    resampled = resampler.resample(start + 20 * step)
+
+    assert resampled == expected


### PR DESCRIPTION
Add option to decide whether the first or the last timestamp of a resampling window should be used.