### PR TITLE
Add `first` and `coalesce` resampling functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,5 +13,7 @@
 - Adds a `first_timestamp` parameter to the resampler to control whether the
   resampled timestamp should be the first timestamp in the buffer or the last
   timestamp in the buffer.
+- Adds `first` resampling function.
+- Adds `coalesce` resampling function.
 
 ## Bug Fixes

--- a/frequenz/resampling/_rust_backend.pyi
+++ b/frequenz/resampling/_rust_backend.pyi
@@ -26,6 +26,10 @@ class ResamplingFunction(Enum):
     """Returns the last sample in the time step"""
     Count = 5
     """Counts the number of samples in the time step"""
+    First = 6
+    """Returns the first sample in the time step"""
+    Coalesce = 7
+    """Returns the first non-None sample in the time step"""
 
     @staticmethod
     def values() -> list[int]:

--- a/src/python.rs
+++ b/src/python.rs
@@ -40,6 +40,8 @@ enum ResamplingFunctionF32 {
     Min,
     Last,
     Count,
+    First,
+    Coalesce,
 }
 
 #[pymethods]
@@ -58,6 +60,8 @@ impl ResamplingFunctionF32 {
             Self::Min.value(),
             Self::Last.value(),
             Self::Count.value(),
+            Self::First.value(),
+            Self::Coalesce.value(),
         ]
     }
 
@@ -70,6 +74,8 @@ impl ResamplingFunctionF32 {
             (Self::Min.to_string(), Self::Min.value()),
             (Self::Last.to_string(), Self::Last.value()),
             (Self::Count.to_string(), Self::Count.value()),
+            (Self::First.to_string(), Self::First.value()),
+            (Self::Coalesce.to_string(), Self::Coalesce.value()),
         ]
     }
 
@@ -95,6 +101,8 @@ impl ResamplingFunctionF32 {
             Self::Min => 3,
             Self::Last => 4,
             Self::Count => 5,
+            Self::First => 6,
+            Self::Coalesce => 7,
         }
     }
 }
@@ -110,6 +118,8 @@ impl TryFrom<i32> for ResamplingFunctionF32 {
             3 => Ok(Self::Min),
             4 => Ok(Self::Last),
             5 => Ok(Self::Count),
+            6 => Ok(Self::First),
+            7 => Ok(Self::Coalesce),
             _ => Err(PyValueError::new_err("Invalid resampling function")),
         }
     }
@@ -125,7 +135,9 @@ impl Display for ResamplingFunctionF32 {
                 ResamplingFunctionF32::Sum => "Sum",
                 ResamplingFunctionF32::Max => "Max",
                 ResamplingFunctionF32::Min => "Min",
+                ResamplingFunctionF32::First => "First",
                 ResamplingFunctionF32::Last => "Last",
+                ResamplingFunctionF32::Coalesce => "Coalesce",
                 ResamplingFunctionF32::Count => "Count",
             }
         )
@@ -139,7 +151,9 @@ impl From<ResamplingFunctionF32> for ResamplingFunction<f32, PythonSample> {
             ResamplingFunctionF32::Sum => ResamplingFunction::Sum,
             ResamplingFunctionF32::Max => ResamplingFunction::Max,
             ResamplingFunctionF32::Min => ResamplingFunction::Min,
+            ResamplingFunctionF32::First => ResamplingFunction::First,
             ResamplingFunctionF32::Last => ResamplingFunction::Last,
+            ResamplingFunctionF32::Coalesce => ResamplingFunction::Coalesce,
             ResamplingFunctionF32::Count => ResamplingFunction::Count,
         }
     }

--- a/src/resampler.rs
+++ b/src/resampler.rs
@@ -42,9 +42,15 @@ pub enum ResamplingFunction<
     /// Calculates the minimum value of all samples in the time step (ignoring
     /// None values)
     Min,
+    /// Uses the first sample in the time step. If the first sample is None, the
+    /// resampling function will return None.
+    First,
     /// Uses the last sample in the time step. If the last sample is None, the
     /// resampling function will return None.
     Last,
+    /// Returns the first non-None sample in the time step. If all samples are
+    /// None, the resampling function will return None.
+    Coalesce,
     /// Counts the number of samples in the time step (ignoring None values)
     Count,
     /// A custom resampling function that takes a closure that takes a slice of
@@ -81,7 +87,9 @@ impl<
                     }
                 })
             }),
+            Self::First => samples.first().and_then(|s| s.value()),
             Self::Last => samples.last().and_then(|s| s.value()),
+            Self::Coalesce => samples.iter().find_map(|s| s.value()),
             Self::Count => Some(
                 T::from_usize(samples.iter().filter_map(|s| s.value()).count())
                     .unwrap_or_else(|| T::zero()),
@@ -102,7 +110,9 @@ impl<
             Self::Sum => write!(f, "Sum"),
             Self::Max => write!(f, "Max"),
             Self::Min => write!(f, "Min"),
+            Self::First => write!(f, "First"),
             Self::Last => write!(f, "Last"),
+            Self::Coalesce => write!(f, "Coalesce"),
             Self::Count => write!(f, "Count"),
             Self::Custom(_) => write!(f, "Custom"),
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,6 +55,60 @@ fn test_resampling(
     assert_eq!(resampled, expected);
 }
 
+fn test_resampling_with_none_first(
+    resampling_function: ResamplingFunction<f64, TestSample>,
+    expected: Vec<TestSample>,
+) {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let mut resampler: Resampler<f64, TestSample> =
+        Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
+    let step = TimeDelta::seconds(1);
+    let data = vec![
+        TestSample::new(start + step, None),
+        TestSample::new(start + step * 2, Some(2.0)),
+        TestSample::new(start + step * 3, Some(3.0)),
+        TestSample::new(start + step * 4, Some(4.0)),
+        TestSample::new(start + step * 5, Some(5.0)),
+        TestSample::new(start + step * 6, None),
+        TestSample::new(start + step * 7, Some(7.0)),
+        TestSample::new(start + step * 8, Some(8.0)),
+        TestSample::new(start + step * 9, Some(9.0)),
+        TestSample::new(start + step * 10, Some(10.0)),
+    ];
+
+    resampler.extend(data);
+
+    let resampled = resampler.resample(start + step * 10);
+    assert_eq!(resampled, expected);
+}
+
+fn test_resampling_with_none_all(
+    resampling_function: ResamplingFunction<f64, TestSample>,
+    expected: Vec<TestSample>,
+) {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let mut resampler: Resampler<f64, TestSample> =
+        Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
+    let step = TimeDelta::seconds(1);
+    let data = vec![
+        TestSample::new(start + step, None),
+        TestSample::new(start + step * 2, None),
+        TestSample::new(start + step * 3, None),
+        TestSample::new(start + step * 4, None),
+        TestSample::new(start + step * 5, None),
+        TestSample::new(start + step * 6, None),
+        TestSample::new(start + step * 7, None),
+        TestSample::new(start + step * 8, None),
+        TestSample::new(start + step * 9, None),
+        TestSample::new(start + step * 10, None),
+    ];
+
+    resampler.extend(data);
+
+    let resampled = resampler.resample(start + step * 10);
+    assert_eq!(resampled, expected);
+}
+
 #[test]
 fn test_resampling_average() {
     test_resampling(
@@ -62,6 +116,22 @@ fn test_resampling_average() {
         vec![
             TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(3.0)),
             TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(8.0)),
+        ],
+    );
+
+    test_resampling_with_none_first(
+        ResamplingFunction::Average,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(3.5)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(8.5)),
+        ],
+    );
+
+    test_resampling_with_none_all(
+        ResamplingFunction::Average,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), None),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
         ],
     );
 }
@@ -75,6 +145,22 @@ fn test_resampling_count() {
             TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(5.0)),
         ],
     );
+
+    test_resampling_with_none_first(
+        ResamplingFunction::Count,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(4.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(4.0)),
+        ],
+    );
+
+    test_resampling_with_none_all(
+        ResamplingFunction::Count,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(0.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(0.0)),
+        ],
+    );
 }
 
 #[test]
@@ -84,6 +170,22 @@ fn test_resampling_sum() {
         vec![
             TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(15.0)),
             TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(40.0)),
+        ],
+    );
+
+    test_resampling_with_none_first(
+        ResamplingFunction::Sum,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(14.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(34.0)),
+        ],
+    );
+
+    test_resampling_with_none_all(
+        ResamplingFunction::Sum,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), None),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
         ],
     );
 }
@@ -97,6 +199,22 @@ fn test_resampling_min() {
             TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(6.0)),
         ],
     );
+
+    test_resampling_with_none_first(
+        ResamplingFunction::Min,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(2.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(7.0)),
+        ],
+    );
+
+    test_resampling_with_none_all(
+        ResamplingFunction::Min,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), None),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
+        ],
+    );
 }
 
 #[test]
@@ -108,6 +226,49 @@ fn test_resampling_max() {
             TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(10.0)),
         ],
     );
+
+    test_resampling_with_none_first(
+        ResamplingFunction::Max,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(5.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(10.0)),
+        ],
+    );
+
+    test_resampling_with_none_all(
+        ResamplingFunction::Max,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), None),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
+        ],
+    );
+}
+
+#[test]
+fn test_resampling_first() {
+    test_resampling(
+        ResamplingFunction::First,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(1.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(6.0)),
+        ],
+    );
+
+    test_resampling_with_none_first(
+        ResamplingFunction::First,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), None),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
+        ],
+    );
+
+    test_resampling_with_none_all(
+        ResamplingFunction::First,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), None),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
+        ],
+    );
 }
 
 #[test]
@@ -117,6 +278,49 @@ fn test_resampling_last() {
         vec![
             TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(5.0)),
             TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(10.0)),
+        ],
+    );
+
+    test_resampling_with_none_first(
+        ResamplingFunction::Last,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(5.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(10.0)),
+        ],
+    );
+
+    test_resampling_with_none_all(
+        ResamplingFunction::Last,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), None),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
+        ],
+    );
+}
+
+#[test]
+fn test_resampling_coalesce() {
+    test_resampling(
+        ResamplingFunction::Coalesce,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(1.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(6.0)),
+        ],
+    );
+
+    test_resampling_with_none_first(
+        ResamplingFunction::Coalesce,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(2.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(7.0)),
+        ],
+    );
+
+    test_resampling_with_none_all(
+        ResamplingFunction::Coalesce,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), None),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
         ],
     );
 }


### PR DESCRIPTION
- `first` takes the first value in an interval, regardless of being None.
- `coalesce` takes the first non-none value in an interval. If all are None, returns None.