### PR TITLE
Restore Python release CI workflow with artifact download fixes

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -1,0 +1,313 @@
+name: Python CI
+
+on:
+  merge_group:
+  push:
+    # We need to explicitly include tags because otherwise when adding
+    # `branches-ignore` it will only trigger on branches.
+    tags:
+      - '*'
+    branches-ignore:
+      # Ignore pushes to merge queues.
+      # We only want to test the merge commit (`merge_group` event), the hashes
+      # in the push were already tested by the PR checks
+      - 'gh-readonly-queue/**'
+      - 'dependabot/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DEFAULT_PYTHON_VERSION: '3.11'
+
+jobs:
+  nox:
+    name: Test with nox
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-24.04
+            target: x86_64
+          - runner: ubuntu-24.04
+            target: x86
+          - runner: ubuntu-24.04
+            target: aarch64
+          - runner: ubuntu-24.04
+            target: armv7
+          - runner: macos-14
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+          - runner: macos-15
+            target: x86_64
+          - runner: macos-15
+            target: aarch64
+        nox-session:
+          - "ci_checks_max"
+          - "pytest_min"
+        python:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    runs-on: ${{ matrix.platform.runner }}
+
+    steps:
+      - name: Run nox
+        uses: frequenz-floss/gh-action-nox@v1.0.1
+        with:
+          python-version: ${{ matrix.python }}
+          nox-session: ${{ matrix.nox-session }}
+
+  # This job runs if all the `nox` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  nox-all:
+    # The job name should match the name of the `nox` job.
+    name: Test with nox
+    needs: ["nox"]
+    # We skip this job only if nox was also skipped
+    if: always() && needs.nox.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.nox.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
+
+  build:
+    name: Build distribution packages
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-24.04
+            target: x86_64
+          - runner: ubuntu-24.04
+            target: x86
+          - runner: ubuntu-24.04
+            target: aarch64
+          - runner: ubuntu-24.04
+            target: armv7
+          - runner: macos-14
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+          - runner: macos-15
+            target: x86_64
+          - runner: macos-15
+            target: aarch64
+        python:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+
+      - name: Fetch sources
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.1
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: build
+
+      - name: Build the source and binary distribution
+        run: python -m build
+
+      - name: Upload distribution files
+        uses: actions/upload-artifact@v5
+        with:
+          name: dist-packages-${{ matrix.platform.runner }}-${{ matrix.platform.target }}-${{ matrix.python }}
+          path: dist/
+          if-no-files-found: error
+
+  # This job runs if all the `build` matrix jobs ran and succeeded.
+  # It is only used to have a single job that we can require in branch
+  # protection rules, so we don't have to update the protection rules each time
+  # we add or remove a job from the matrix.
+  build-all:
+    # The job name should match the name of the `build` job.
+    name: Build distribution packages
+    needs: ["build"]
+    # We skip this job only if build was also skipped
+    if: always() && needs.build.result != 'skipped'
+    runs-on: ubuntu-24.04
+    env:
+      DEPS_RESULT: ${{ needs.build.result }}
+    steps:
+      - name: Check matrix job result
+        run: test "$DEPS_RESULT" = "success"
+
+  test-docs:
+    name: Test documentation website generation
+    if: github.event_name != 'push'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+
+      - name: Fetch sources
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.1
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Generate the documentation
+        env:
+          MIKE_VERSION: gh-${{ github.job }}
+        run: |
+          mike deploy $MIKE_VERSION
+          mike set-default $MIKE_VERSION
+
+      - name: Upload site
+        uses: actions/upload-artifact@v5
+        with:
+          name: docs-site
+          path: site/
+          if-no-files-found: error
+
+  publish-docs:
+    name: Publish documentation website to GitHub pages
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    needs: ["nox-all", "build-all"]
+    permissions:
+      contents: write
+    steps:
+      - name: Setup Git
+        uses: frequenz-floss/gh-action-setup-git@v1.0.0
+
+      - name: Fetch sources
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Setup Python
+        uses: frequenz-floss/gh-action-setup-python-with-deps@v1.0.1
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
+          dependencies: .[dev-mkdocs]
+
+      - name: Calculate and check version
+        id: mike-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          python -m frequenz.repo.config.cli.version.mike.info
+
+      - name: Fetch the gh-pages branch
+        if: steps.mike-version.outputs.version
+        run: git fetch origin gh-pages --depth=1
+
+      - name: Build site
+        if: steps.mike-version.outputs.version
+        env:
+          VERSION: ${{ steps.mike-version.outputs.version }}
+          TITLE: ${{ steps.mike-version.outputs.title }}
+          ALIASES: ${{ steps.mike-version.outputs.aliases }}
+          # This is not ideal, we need to define all these variables here
+          # because we need to calculate all the repository version information
+          # to be able to show the correct versions in the documentation when
+          # building it.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          GIT_REF: ${{ github.ref }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          mike deploy --update-aliases --title "$TITLE" "$VERSION" $ALIASES
+
+      - name: Sort site versions
+        if: steps.mike-version.outputs.version
+        run: |
+          git checkout gh-pages
+          python -m frequenz.repo.config.cli.version.mike.sort versions.json
+          git commit -a -m "Sort versions.json"
+
+      - name: Publish site
+        if: steps.mike-version.outputs.version
+        run: |
+          git push origin gh-pages
+
+  create-github-release:
+    name: Create GitHub release
+    needs: ["publish-docs"]
+    # Create a release only on tags creation
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      # We need write permissions on contents to create GitHub releases and on
+      # discussions to create the release announcement in the discussion forums
+      contents: write
+      discussions: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download distribution files
+        uses: actions/download-artifact@v6
+        with:
+          pattern: dist-packages-*
+          path: dist
+          merge-multiple: true
+
+      - name: Download RELEASE_NOTES.md
+        run: |
+          set -ux
+          gh api \
+              -X GET \
+              -f ref=$REF \
+              -H "Accept: application/vnd.github.raw" \
+              "/repos/$REPOSITORY/contents/RELEASE_NOTES.md" \
+            > RELEASE_NOTES.md
+        env:
+          REF: ${{ github.ref }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        run: |
+          set -ux
+          extra_opts=
+          if echo "$REF_NAME" | grep -- -; then extra_opts=" --prerelease"; fi
+          gh release create \
+            -R "$REPOSITORY" \
+            --notes-file RELEASE_NOTES.md \
+            --generate-notes \
+            $extra_opts \
+            $REF_NAME \
+            dist/*
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-to-pypi:
+    name: Publish packages to PyPI
+    needs: ["create-github-release"]
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      # For trusted publishing. See:
+      # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+      id-token: write
+    steps:
+      - name: Download distribution files
+        uses: actions/download-artifact@v6
+        with:
+          pattern: dist-packages-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish the Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,3 +3,7 @@
 ## New Features
 
 - `ResamplingFunction` now implements `Clone`.
+
+## Bug Fixes
+
+- Restored Python release CI workflow with fixes for artifact downloads.


### PR DESCRIPTION
## Summary
- Restores the Python CI workflow that was previously removed due to broken artifact downloads
- Fixes artifact download in `create-github-release` and `publish-to-pypi` jobs by using `pattern: dist-packages-*` with `merge-multiple: true` instead of undefined matrix variables
- Adds `environment: release` to enable PyPI trusted publishing

Closes #70