### PR TITLE
feat: add one-shot resample function for simplified resampling

### DIFF
--- a/.github/workflows/python-ci-pr.yaml
+++ b/.github/workflows/python-ci-pr.yaml
@@ -1,12 +1,13 @@
 name: Python Test PR
 
 on:
+  merge_group:
   pull_request:
 
 env:
   # Please make sure this version is included in the `matrix`, as the
   # `matrix` section can't use `env`, so it must be entered manually
-  DEFAULT_PYTHON_VERSION: '3.11'
+  DEFAULT_PYTHON_VERSION: "3.11"
   # It would be nice to be able to also define a DEFAULT_UBUNTU_VERSION
   # but sadly `env` can't be used either in `runs-on`.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For simple use cases where you want to resample data in a single call, use the `
 
 ```python
 import datetime as dt
-from frequenz.resampling import resample, ResamplingFunction
+from frequenz.resampling import Closed, Label, resample, ResamplingFunction
 
 start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
 step = dt.timedelta(seconds=1)
@@ -99,8 +99,8 @@ result = resample(
     data,
     dt.timedelta(seconds=5),
     ResamplingFunction.Average,
-    closed="left",
-    label="left",
+    closed=Closed.Left,
+    label=Label.Left,
 )
 # Result: [(t=0, 3.0), (t=5, 8.0)]
 ```
@@ -116,7 +116,7 @@ first resampled sample.
 
 ```python
 import datetime as dt
-from frequenz.resampling import Resampler, ResamplingFunction
+from frequenz.resampling import Closed, Label, Resampler, ResamplingFunction
 
 
 start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
@@ -126,8 +126,8 @@ resampler = Resampler(
     ResamplingFunction.Average,
     max_age_in_intervals=1,
     start=start,
-    closed="left",
-    label="right",
+    closed=Closed.Left,
+    label=Label.Right,
 )
 
 for i in range(10):

--- a/README.md
+++ b/README.md
@@ -7,7 +7,27 @@ This project is the rust resampler for resampling a stream of samples to a given
 
 ## Usage in Rust
 
-To resample a vector of samples to a given interval, you can use the `Resampler` struct.
+### One-Shot Resampling
+
+For simple use cases where you want to resample data in a single call, use the `resample()` function:
+
+```rust
+use chrono::{DateTime, TimeDelta, Utc};
+use frequenz_resampling::{resample, ResamplingFunction, SimpleSample};
+
+let start = DateTime::from_timestamp(0, 0).unwrap();
+let step = TimeDelta::seconds(1);
+let data: Vec<(DateTime<Utc>, Option<f64>)> = (0..10)
+    .map(|i| (start + step * i, Some((i + 1) as f64)))
+    .collect();
+
+let result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Average, true);
+// Result: [(t=0, 3.0), (t=5, 8.0)]
+```
+
+### Stateful Resampling
+
+For streaming use cases where you need to push samples over time, use the `Resampler` struct.
 The construction of a resampler expects an interval (`TimeDelta`) and a
 `ResamplingFunction`.
 Moreover, the `max_age_in_intervals` parameter can be used to control the maximum age of a sample.
@@ -50,7 +70,25 @@ assert_eq!(resampled, expected);
 
 ## Usage in Python
 
-To resample a stream of samples to a given interval, you can use the `Resampler`
+### One-Shot Resampling
+
+For simple use cases where you want to resample data in a single call, use the `resample()` function:
+
+```python
+import datetime as dt
+from frequenz.resampling import resample, ResamplingFunction
+
+start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+step = dt.timedelta(seconds=1)
+data = [(start + i * step, float(i + 1)) for i in range(10)]
+
+result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+# Result: [(t=0, 3.0), (t=5, 8.0)]
+```
+
+### Stateful Resampling
+
+For streaming use cases where you need to push samples over time, use the `Resampler`
 class.
 The construction of a resampler expects an interval (`datetime.timedelta`),
 a `ResamplingFunction`, a `max_age_in_intervals` parameter to control the

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For simple use cases where you want to resample data in a single call, use the `
 
 ```rust
 use chrono::{DateTime, TimeDelta, Utc};
-use frequenz_resampling::{resample, ResamplingFunction, SimpleSample};
+use frequenz_resampling::{resample, Closed, Label, ResamplingFunction, SimpleSample};
 
 let start = DateTime::from_timestamp(0, 0).unwrap();
 let step = TimeDelta::seconds(1);
@@ -21,7 +21,13 @@ let data: Vec<(DateTime<Utc>, Option<f64>)> = (0..10)
     .map(|i| (start + step * i, Some((i + 1) as f64)))
     .collect();
 
-let result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Average, true);
+let result = resample(
+    &data,
+    TimeDelta::seconds(5),
+    ResamplingFunction::Average,
+    Closed::Left,
+    Label::Left,
+);
 // Result: [(t=0, 3.0), (t=5, 8.0)]
 ```
 
@@ -36,11 +42,18 @@ The `start` parameter is used to set the start time of the first resampled sampl
 
 ```rust
 use chrono::{DateTime, TimeDelta};
-use frequenz_resampling::{Resampler, ResamplingFunction, Sample};
+use frequenz_resampling::{Closed, Label, Resampler, ResamplingFunction, Sample};
 
 let start = DateTime::from_timestamp(0, 0).unwrap();
 let mut resampler: Resampler<f64, TestSample> =
-    Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start, false);
+    Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        Closed::Left,
+        Label::Right,
+    );
 let step = TimeDelta::seconds(1);
 let data = vec![
     TestSample::new(start, Some(1.0)),
@@ -82,7 +95,13 @@ start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
 step = dt.timedelta(seconds=1)
 data = [(start + i * step, float(i + 1)) for i in range(10)]
 
-result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+result = resample(
+    data,
+    dt.timedelta(seconds=5),
+    ResamplingFunction.Average,
+    closed="left",
+    label="left",
+)
 # Result: [(t=0, 3.0), (t=5, 8.0)]
 ```
 
@@ -107,7 +126,8 @@ resampler = Resampler(
     ResamplingFunction.Average,
     max_age_in_intervals=1,
     start=start,
-    first_timestamp=False,
+    closed="left",
+    label="right",
 )
 
 for i in range(10):

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Frequenz Resampling Release Notes
 
+## Bug Fixes
+
+- Fixed `first_timestamp` parameter to only affect output timestamp labeling, not interval grouping. Previously, setting `first_timestamp=false` would shift interval boundaries, causing the first sample at `t=0` to be excluded. Now intervals are consistently `[start, end)` regardless of `first_timestamp` value.
+
 ## New Features
 
 - `ResamplingFunction` now implements `Clone`.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,3 +7,4 @@
 ## New Features
 
 - `ResamplingFunction` now implements `Clone`.
+- Added `resample()` function for one-shot resampling without managing a `Resampler` instance. Available in both Rust and Python.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,18 @@
 # Frequenz Resampling Release Notes
 
+## Breaking Changes
+
+- **API Refactoring**: Replaced the single boolean `first_timestamp` parameter with two explicit parameters in `Resampler` and `resample()`:
+  - `closed` (`Closed` enum in Rust, `"left"` or `"right"` string in Python): Controls which interval edge is closed for sample membership.
+  - `label` (`Label` enum in Rust, `"left"` or `"right"` string in Python): Controls which interval edge is used for output timestamps.
+  - This improves API clarity by explicitly separating interval membership semantics from output timestamp labeling.
+
 ## Bug Fixes
 
-- Fixed `first_timestamp` parameter to only affect output timestamp labeling, not interval grouping. Previously, setting `first_timestamp=false` would shift interval boundaries, causing the first sample at `t=0` to be excluded. Now intervals are consistently `[start, end)` regardless of `first_timestamp` value.
+- Fixed the interval timestamp labeling option to only affect output timestamp labeling, not interval grouping. Previously, using the right-edge label would shift interval boundaries, causing the first sample at `t=0` to be excluded. Now intervals are consistently `[start, end)` regardless of which label is used.
 
 ## New Features
 
 - `ResamplingFunction` now implements `Clone`.
 - Added `resample()` function for one-shot resampling without managing a `Resampler` instance. Available in both Rust and Python.
+- New `Closed` and `Label` enums provide explicit control over interval semantics and output timestamp labeling.

--- a/frequenz/resampling/__init__.py
+++ b/frequenz/resampling/__init__.py
@@ -4,9 +4,11 @@
 """Frequenz Resampling Python Bindings."""
 
 from ._rust_backend import (  # noqa: F401, F403 # pylint: disable=E0401
+    Closed,
+    Label,
     Resampler,
     ResamplingFunction,
     resample,
 )
 
-__all__ = ["Resampler", "ResamplingFunction", "resample"]
+__all__ = ["Closed", "Label", "Resampler", "ResamplingFunction", "resample"]

--- a/frequenz/resampling/__init__.py
+++ b/frequenz/resampling/__init__.py
@@ -6,6 +6,7 @@
 from ._rust_backend import (  # noqa: F401, F403 # pylint: disable=E0401
     Resampler,
     ResamplingFunction,
+    resample,
 )
 
-__all__ = ["Resampler", "ResamplingFunction"]
+__all__ = ["Resampler", "ResamplingFunction", "resample"]

--- a/frequenz/resampling/_rust_backend.pyi
+++ b/frequenz/resampling/_rust_backend.pyi
@@ -1,11 +1,11 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-__all__ = "Resampler", "ResamplingFunction", "resample"
+__all__ = "Closed", "Label", "Resampler", "ResamplingFunction", "resample"
 
 from datetime import datetime, timedelta
 from enum import Enum, unique
-from typing import Literal, Optional, Sequence
+from typing import Optional, Sequence
 
 @unique
 class ResamplingFunction(Enum):
@@ -49,6 +49,40 @@ class ResamplingFunction(Enum):
             A list of all members of the enum.
         """
 
+@unique
+class Closed(Enum):
+    """Controls which edge of an interval is closed for sample membership."""
+
+    Left = 0
+    """Left-closed, right-open intervals: `[start, end)`"""
+    Right = 1
+    """Left-open, right-closed intervals: `(start, end]`"""
+
+    @staticmethod
+    def values() -> list[int]:
+        """Returns a list of all values of the enum."""
+
+    @staticmethod
+    def members() -> list[tuple[str, int]]:
+        """Returns a list of all members of the enum."""
+
+@unique
+class Label(Enum):
+    """Controls which edge of an interval is used as the output timestamp."""
+
+    Left = 0
+    """Use the interval start as the output timestamp"""
+    Right = 1
+    """Use the interval end as the output timestamp"""
+
+    @staticmethod
+    def values() -> list[int]:
+        """Returns a list of all values of the enum."""
+
+    @staticmethod
+    def members() -> list[tuple[str, int]]:
+        """Returns a list of all members of the enum."""
+
 class Resampler:
     """
     The Resampler class is used to resample a time series of samples.
@@ -65,8 +99,8 @@ class Resampler:
         *,
         max_age_in_intervals: int,
         start: datetime,
-        closed: Literal["left", "right"],
-        label: Literal["left", "right"],
+        closed: Closed,
+        label: Label,
     ):
         """
         Initializes a new Resampler object.
@@ -76,12 +110,13 @@ class Resampler:
             resampling_function: The resampling function.
             max_age_in_intervals: The maximum age of a sample in intervals.
             start: The start time of the resampling.
-            closed: Controls which interval edge is closed for sample
-                membership. Use `"left"` for `[start, end)` intervals or
-                `"right"` for `(start, end]` intervals.
-            label: Controls the output timestamp labeling. Use `"left"` to
-                label each interval with its start or `"right"` to label it
-                with its end.
+            closed: Which interval edge is closed for sample membership. Use
+                `"left"` for left-closed, right-open intervals `[start, end)`
+                and `"right"` for right-closed, left-open intervals
+                `(start, end]`.
+            label: Which interval edge to use for output timestamps. Use
+                `"left"` for the left bin edge and `"right"` for the right
+                bin edge.
         """
 
     def push_sample(self, *, timestamp: datetime, value: Optional[float]) -> None:
@@ -113,8 +148,8 @@ def resample(
     interval: timedelta,
     method: ResamplingFunction,
     *,
-    closed: Literal["left", "right"],
-    label: Literal["left", "right"],
+    closed: Closed,
+    label: Label,
 ) -> list[tuple[datetime, Optional[float]]]:
     """
     Resamples a list of timestamp/value pairs in a single call.
@@ -127,10 +162,10 @@ def resample(
         interval: The resampling interval.
         method: The resampling function to use for aggregating values within each interval.
         closed: Which interval edge is closed for sample membership. Use
-            `"left"` for `[start, end)` intervals or `"right"` for
-            `(start, end]` intervals.
+            `"left"` for left-closed, right-open intervals `[start, end)`
+            and `"right"` for right-closed, left-open intervals `(start, end]`.
         label: Which interval edge to use for output timestamps. Use `"left"`
-            for the interval start or `"right"` for the interval end.
+            for the left bin edge and `"right"` for the right bin edge.
 
     Returns:
         A list of (timestamp, value) tuples representing the resampled data.

--- a/frequenz/resampling/_rust_backend.pyi
+++ b/frequenz/resampling/_rust_backend.pyi
@@ -5,7 +5,7 @@ __all__ = "Resampler", "ResamplingFunction", "resample"
 
 from datetime import datetime, timedelta
 from enum import Enum, unique
-from typing import Optional, Sequence
+from typing import Literal, Optional, Sequence
 
 @unique
 class ResamplingFunction(Enum):
@@ -65,7 +65,8 @@ class Resampler:
         *,
         max_age_in_intervals: int,
         start: datetime,
-        first_timestamp: bool = True,
+        closed: Literal["left", "right"],
+        label: Literal["left", "right"],
     ):
         """
         Initializes a new Resampler object.
@@ -75,10 +76,12 @@ class Resampler:
             resampling_function: The resampling function.
             max_age_in_intervals: The maximum age of a sample in intervals.
             start: The start time of the resampling.
-            first_timestamp: Controls the output timestamp labeling. If `True`,
-                the output timestamp is set to the start of the interval. If `False`,
-                the output timestamp is set to the end of the interval. This does not
-                affect how samples are grouped into intervals. Defaults to `True`.
+            closed: Controls which interval edge is closed for sample
+                membership. Use `"left"` for `[start, end)` intervals or
+                `"right"` for `(start, end]` intervals.
+            label: Controls the output timestamp labeling. Use `"left"` to
+                label each interval with its start or `"right"` to label it
+                with its end.
         """
 
     def push_sample(self, *, timestamp: datetime, value: Optional[float]) -> None:
@@ -110,7 +113,8 @@ def resample(
     interval: timedelta,
     method: ResamplingFunction,
     *,
-    first_timestamp: bool = True,
+    closed: Literal["left", "right"],
+    label: Literal["left", "right"],
 ) -> list[tuple[datetime, Optional[float]]]:
     """
     Resamples a list of timestamp/value pairs in a single call.
@@ -122,8 +126,11 @@ def resample(
         data: A list of (timestamp, value) tuples to resample. Must be sorted by timestamp.
         interval: The resampling interval.
         method: The resampling function to use for aggregating values within each interval.
-        first_timestamp: If True, output timestamps are set to the start of each interval.
-            If False, output timestamps are set to the end of each interval. Defaults to True.
+        closed: Which interval edge is closed for sample membership. Use
+            `"left"` for `[start, end)` intervals or `"right"` for
+            `(start, end]` intervals.
+        label: Which interval edge to use for output timestamps. Use `"left"`
+            for the interval start or `"right"` for the interval end.
 
     Returns:
         A list of (timestamp, value) tuples representing the resampled data.

--- a/frequenz/resampling/_rust_backend.pyi
+++ b/frequenz/resampling/_rust_backend.pyi
@@ -75,9 +75,10 @@ class Resampler:
             resampling_function: The resampling function.
             max_age_in_intervals: The maximum age of a sample in intervals.
             start: The start time of the resampling.
-            first_timestamp: Whether the resampled timestamp should be the first
-                timestamp in the buffer or the last timestamp in the buffer.
-                Defaults to `True`.
+            first_timestamp: Controls the output timestamp labeling. If `True`,
+                the output timestamp is set to the start of the interval. If `False`,
+                the output timestamp is set to the end of the interval. This does not
+                affect how samples are grouped into intervals. Defaults to `True`.
         """
 
     def push_sample(self, *, timestamp: datetime, value: Optional[float]) -> None:

--- a/frequenz/resampling/_rust_backend.pyi
+++ b/frequenz/resampling/_rust_backend.pyi
@@ -1,11 +1,11 @@
 # License: MIT
 # Copyright © 2024 Frequenz Energy-as-a-Service GmbH
 
-__all__ = "Resampler", "ResamplingFunction"
+__all__ = "Resampler", "ResamplingFunction", "resample"
 
 from datetime import datetime, timedelta
 from enum import Enum, unique
-from typing import Optional
+from typing import Optional, Sequence
 
 @unique
 class ResamplingFunction(Enum):
@@ -103,3 +103,28 @@ class Resampler:
         Returns:
             A list of tuples with the resampled samples.
         """
+
+
+def resample(
+    data: Sequence[tuple[datetime, Optional[float]]],
+    interval: timedelta,
+    method: ResamplingFunction,
+    *,
+    first_timestamp: bool = True,
+) -> list[tuple[datetime, Optional[float]]]:
+    """
+    Resamples a list of timestamp/value pairs in a single call.
+
+    This is a convenience function for one-shot resampling without needing to
+    manage a `Resampler` instance.
+
+    Args:
+        data: A list of (timestamp, value) tuples to resample. Must be sorted by timestamp.
+        interval: The resampling interval.
+        method: The resampling function to use for aggregating values within each interval.
+        first_timestamp: If True, output timestamps are set to the start of each interval.
+            If False, output timestamps are set to the end of each interval. Defaults to True.
+
+    Returns:
+        A list of (timestamp, value) tuples representing the resampled data.
+    """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev-pylint = [
   "frequenz-resampling[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
 dev-pytest = [
+  "pandas == 2.3.3",
   "pytest == 8.4.2",
   "pytest-mock == 3.15.1",
   "pytest-asyncio == 1.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pandas == 2.3.3",
+  "pandas-stubs == 2.3.2.250926",
   "pytest == 8.4.2",
   "pytest-mock == 3.15.1",
   "pytest-asyncio == 1.2.0",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ the buffer.
 
 ```rust
 use chrono::{DateTime, TimeDelta, Utc};
-use frequenz_resampling::{Resampler, ResamplingFunction, Sample};
+use frequenz_resampling::{Closed, Label, Resampler, ResamplingFunction, Sample};
 
 #[derive(Debug, Clone, Default, Copy, PartialEq)]
 pub(crate) struct TestSample {
@@ -44,7 +44,14 @@ impl Sample for TestSample {
 
 let start = DateTime::from_timestamp(0, 0).unwrap();
 let mut resampler: Resampler<f64, TestSample> =
-    Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start, false);
+    Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        Closed::Left,
+        Label::Right,
+    );
 
 let step = TimeDelta::seconds(1);
 // Data starts at t=0 with values 1-10
@@ -87,7 +94,7 @@ mod python;
 mod resampling_function;
 pub use resampling_function::ResamplingFunction;
 
-pub use resampler::{epoch_align, Resampler, Sample};
+pub use resampler::{epoch_align, Closed, Label, Resampler, Sample};
 
 use chrono::{DateTime, TimeDelta, Utc};
 
@@ -124,8 +131,12 @@ impl Sample for SimpleSample {
 /// * `data` - A slice of (timestamp, value) tuples to resample. Must be sorted by timestamp.
 /// * `interval` - The resampling interval.
 /// * `resampling_function` - The function to use for aggregating values within each interval.
-/// * `first_timestamp` - If `true`, output timestamps are set to the start of each interval.
-///   If `false`, output timestamps are set to the end of each interval.
+/// * `closed` - Controls which edge of the interval is closed for sample membership.
+///   Use [`Closed::Left`] for `[start, end)` intervals or [`Closed::Right`] for
+///   `(start, end]` intervals.
+/// * `label` - Controls which edge of the interval is used for output timestamps.
+///   Use [`Label::Left`] for the start of each interval or [`Label::Right`] for
+///   the end of each interval.
 ///
 /// # Returns
 ///
@@ -135,7 +146,7 @@ impl Sample for SimpleSample {
 ///
 /// ```rust
 /// use chrono::{DateTime, TimeDelta, Utc};
-/// use frequenz_resampling::{resample, ResamplingFunction, SimpleSample};
+/// use frequenz_resampling::{resample, Closed, Label, ResamplingFunction};
 ///
 /// let start = DateTime::from_timestamp(0, 0).unwrap();
 /// let step = TimeDelta::seconds(1);
@@ -143,7 +154,13 @@ impl Sample for SimpleSample {
 ///     .map(|i| (start + step * i, Some((i + 1) as f64)))
 ///     .collect();
 ///
-/// let result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Average, true);
+/// let result = resample(
+///     &data,
+///     TimeDelta::seconds(5),
+///     ResamplingFunction::Average,
+///     Closed::Left,
+///     Label::Left,
+/// );
 /// // Result: [(t=0, 3.0), (t=5, 8.0)]
 /// assert_eq!(result.len(), 2);
 /// assert_eq!(result[0].1, Some(3.0));
@@ -153,7 +170,8 @@ pub fn resample(
     data: &[(DateTime<Utc>, Option<f64>)],
     interval: TimeDelta,
     resampling_function: ResamplingFunction<f64, SimpleSample>,
-    first_timestamp: bool,
+    closed: Closed,
+    label: Label,
 ) -> Vec<(DateTime<Utc>, Option<f64>)> {
     let (Some(first_ts), Some(last_ts)) = (
         data.first().map(|(ts, _)| *ts),
@@ -170,7 +188,8 @@ pub fn resample(
         resampling_function,
         1,
         aligned_start,
-        first_timestamp,
+        closed,
+        label,
     );
     resampler.extend(data.iter().map(|(ts, val)| SimpleSample::new(*ts, *val)));
     resampler

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,11 @@ impl Sample for SimpleSample {
 ///
 /// A vector of (timestamp, value) tuples representing the resampled data.
 ///
+/// The helper mirrors pandas-style bucket coverage for the input range. In
+/// particular, with [`Closed::Right`], it includes the leading bucket that
+/// ends exactly at the first sample timestamp when that timestamp lies on an
+/// interval boundary.
+///
 /// # Example
 ///
 /// ```rust
@@ -181,16 +186,20 @@ pub fn resample(
     };
 
     let aligned_start = epoch_align(interval, first_ts, None);
-    let end = epoch_align(interval, last_ts, None) + interval;
+    let aligned_end = epoch_align(interval, last_ts, None);
+    let start = if closed == Closed::Right && first_ts == aligned_start {
+        aligned_start - interval
+    } else {
+        aligned_start
+    };
+    let end = if closed == Closed::Right && last_ts == aligned_end {
+        aligned_end
+    } else {
+        aligned_end + interval
+    };
 
-    let mut resampler: Resampler<f64, SimpleSample> = Resampler::new(
-        interval,
-        resampling_function,
-        1,
-        aligned_start,
-        closed,
-        label,
-    );
+    let mut resampler: Resampler<f64, SimpleSample> =
+        Resampler::new(interval, resampling_function, 1, start, closed, label);
     resampler.extend(data.iter().map(|(ts, val)| SimpleSample::new(*ts, *val)));
     resampler
         .resample(end)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,17 +47,20 @@ let mut resampler: Resampler<f64, TestSample> =
     Resampler::new(TimeDelta::seconds(5), ResamplingFunction::Average, 1, start, false);
 
 let step = TimeDelta::seconds(1);
+// Data starts at t=0 with values 1-10
+// Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → avg = 3.0
+// Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → avg = 8.0
 let data = vec![
-    TestSample::new(start + step, Some(1.0)),
-    TestSample::new(start + step * 2, Some(2.0)),
-    TestSample::new(start + step * 3, Some(3.0)),
-    TestSample::new(start + step * 4, Some(4.0)),
-    TestSample::new(start + step * 5, Some(5.0)),
-    TestSample::new(start + step * 6, Some(6.0)),
-    TestSample::new(start + step * 7, Some(7.0)),
-    TestSample::new(start + step * 8, Some(8.0)),
-    TestSample::new(start + step * 9, Some(9.0)),
-    TestSample::new(start + step * 10, Some(10.0)),
+    TestSample::new(start, Some(1.0)),
+    TestSample::new(start + step, Some(2.0)),
+    TestSample::new(start + step * 2, Some(3.0)),
+    TestSample::new(start + step * 3, Some(4.0)),
+    TestSample::new(start + step * 4, Some(5.0)),
+    TestSample::new(start + step * 5, Some(6.0)),
+    TestSample::new(start + step * 6, Some(7.0)),
+    TestSample::new(start + step * 7, Some(8.0)),
+    TestSample::new(start + step * 8, Some(9.0)),
+    TestSample::new(start + step * 9, Some(10.0)),
 ];
 
 resampler.extend(data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,4 +87,95 @@ mod python;
 mod resampling_function;
 pub use resampling_function::ResamplingFunction;
 
-pub use resampler::{Resampler, Sample};
+pub use resampler::{epoch_align, Resampler, Sample};
+
+use chrono::{DateTime, TimeDelta, Utc};
+
+/// A simple sample type for use with the `resample` function.
+#[derive(Default, Clone, Debug, Copy, PartialEq)]
+pub struct SimpleSample {
+    timestamp: DateTime<Utc>,
+    value: Option<f64>,
+}
+
+impl Sample for SimpleSample {
+    type Value = f64;
+
+    fn new(timestamp: DateTime<Utc>, value: Option<f64>) -> Self {
+        Self { timestamp, value }
+    }
+
+    fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    fn value(&self) -> Option<f64> {
+        self.value
+    }
+}
+
+/// Resamples a list of timestamp/value pairs in a single call.
+///
+/// This is a convenience function for one-shot resampling without needing to
+/// manage a `Resampler` instance.
+///
+/// # Arguments
+///
+/// * `data` - A slice of (timestamp, value) tuples to resample. Must be sorted by timestamp.
+/// * `interval` - The resampling interval.
+/// * `resampling_function` - The function to use for aggregating values within each interval.
+/// * `first_timestamp` - If `true`, output timestamps are set to the start of each interval.
+///   If `false`, output timestamps are set to the end of each interval.
+///
+/// # Returns
+///
+/// A vector of (timestamp, value) tuples representing the resampled data.
+///
+/// # Example
+///
+/// ```rust
+/// use chrono::{DateTime, TimeDelta, Utc};
+/// use frequenz_resampling::{resample, ResamplingFunction, SimpleSample};
+///
+/// let start = DateTime::from_timestamp(0, 0).unwrap();
+/// let step = TimeDelta::seconds(1);
+/// let data: Vec<(DateTime<Utc>, Option<f64>)> = (0..10)
+///     .map(|i| (start + step * i, Some((i + 1) as f64)))
+///     .collect();
+///
+/// let result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Average, true);
+/// // Result: [(t=0, 3.0), (t=5, 8.0)]
+/// assert_eq!(result.len(), 2);
+/// assert_eq!(result[0].1, Some(3.0));
+/// assert_eq!(result[1].1, Some(8.0));
+/// ```
+pub fn resample(
+    data: &[(DateTime<Utc>, Option<f64>)],
+    interval: TimeDelta,
+    resampling_function: ResamplingFunction<f64, SimpleSample>,
+    first_timestamp: bool,
+) -> Vec<(DateTime<Utc>, Option<f64>)> {
+    let (Some(first_ts), Some(last_ts)) = (
+        data.first().map(|(ts, _)| *ts),
+        data.last().map(|(ts, _)| *ts),
+    ) else {
+        return vec![];
+    };
+
+    let aligned_start = epoch_align(interval, first_ts, None);
+    let end = epoch_align(interval, last_ts, None) + interval;
+
+    let mut resampler: Resampler<f64, SimpleSample> = Resampler::new(
+        interval,
+        resampling_function,
+        1,
+        aligned_start,
+        first_timestamp,
+    );
+    resampler.extend(data.iter().map(|(ts, val)| SimpleSample::new(*ts, *val)));
+    resampler
+        .resample(end)
+        .into_iter()
+        .map(|s| (s.timestamp(), s.value()))
+        .collect()
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,4 +1,4 @@
-use crate::{resampler::Resampler, ResamplingFunction, Sample};
+use crate::{resampler::Resampler, Closed, Label, ResamplingFunction, Sample};
 use chrono::{DateTime, TimeDelta, Utc};
 use pyo3::{exceptions::PyValueError, prelude::*};
 use std::fmt::Display;
@@ -174,6 +174,26 @@ impl From<ResamplingFunctionF32> for ResamplingFunction<f64, crate::SimpleSample
     }
 }
 
+fn parse_label(label: &str) -> PyResult<Label> {
+    match label {
+        "left" => Ok(Label::Left),
+        "right" => Ok(Label::Right),
+        _ => Err(PyValueError::new_err(
+            "Invalid label, expected 'left' or 'right'",
+        )),
+    }
+}
+
+fn parse_closed(closed: &str) -> PyResult<Closed> {
+    match closed {
+        "left" => Ok(Closed::Left),
+        "right" => Ok(Closed::Right),
+        _ => Err(PyValueError::new_err(
+            "Invalid closed value, expected 'left' or 'right'",
+        )),
+    }
+}
+
 /// Resamples a list of timestamp/value pairs in a single call.
 ///
 /// This is a convenience function for one-shot resampling without needing to
@@ -183,18 +203,22 @@ impl From<ResamplingFunctionF32> for ResamplingFunction<f64, crate::SimpleSample
 ///     data: A list of (timestamp, value) tuples to resample. Must be sorted by timestamp.
 ///     interval: The resampling interval.
 ///     method: The resampling function to use for aggregating values within each interval.
-///     first_timestamp: If True, output timestamps are set to the start of each interval.
-///         If False, output timestamps are set to the end of each interval. Defaults to True.
+///     closed: Which interval edge is closed for sample membership. Use
+///         `"left"` for `[start, end)` intervals or `"right"` for
+///         `(start, end]` intervals.
+///     label: Which interval edge to use for output timestamps. Use `"left"`
+///         for the interval start or `"right"` for the interval end.
 ///
 /// Returns:
 ///     A list of (timestamp, value) tuples representing the resampled data.
 #[pyfunction]
-#[pyo3(signature = (data, interval, method, *, first_timestamp=true))]
+#[pyo3(signature = (data, interval, method, *, closed, label))]
 fn resample(
     data: Vec<(DateTime<Utc>, Option<f32>)>,
     interval: TimeDelta,
     method: ResamplingFunctionF32,
-    first_timestamp: bool,
+    closed: &str,
+    label: &str,
 ) -> PyResult<Vec<(DateTime<Utc>, Option<f32>)>> {
     // Convert f32 to f64 for the Rust implementation
     let data_f64: Vec<(DateTime<Utc>, Option<f64>)> = data
@@ -203,7 +227,13 @@ fn resample(
         .collect();
 
     // Call the Rust implementation
-    let result = crate::resample(&data_f64, interval, method.into(), first_timestamp);
+    let result = crate::resample(
+        &data_f64,
+        interval,
+        method.into(),
+        parse_closed(closed)?,
+        parse_label(label)?,
+    );
 
     // Convert f64 back to f32
     Ok(result
@@ -221,23 +251,25 @@ struct ResamplerF32 {
 #[pymethods]
 impl ResamplerF32 {
     #[new]
-    #[pyo3(signature = (interval, resampling_function, *, max_age_in_intervals, start, first_timestamp=true))]
+    #[pyo3(signature = (interval, resampling_function, *, max_age_in_intervals, start, closed, label))]
     fn new(
         interval: TimeDelta,
         resampling_function: ResamplingFunctionF32,
         max_age_in_intervals: i32,
         start: DateTime<Utc>,
-        first_timestamp: bool,
-    ) -> Self {
-        Self {
+        closed: &str,
+        label: &str,
+    ) -> PyResult<Self> {
+        Ok(Self {
             inner: Resampler::new(
                 interval,
                 resampling_function.into(),
                 max_age_in_intervals,
                 start,
-                first_timestamp,
+                parse_closed(closed)?,
+                parse_label(label)?,
             ),
-        }
+        })
     }
 
     #[pyo3(signature = (*, timestamp, value))]

--- a/src/python.rs
+++ b/src/python.rs
@@ -159,6 +159,59 @@ impl From<ResamplingFunctionF32> for ResamplingFunction<f32, PythonSample> {
     }
 }
 
+impl From<ResamplingFunctionF32> for ResamplingFunction<f64, crate::SimpleSample> {
+    fn from(resampling_function: ResamplingFunctionF32) -> Self {
+        match resampling_function {
+            ResamplingFunctionF32::Average => ResamplingFunction::Average,
+            ResamplingFunctionF32::Sum => ResamplingFunction::Sum,
+            ResamplingFunctionF32::Max => ResamplingFunction::Max,
+            ResamplingFunctionF32::Min => ResamplingFunction::Min,
+            ResamplingFunctionF32::First => ResamplingFunction::First,
+            ResamplingFunctionF32::Last => ResamplingFunction::Last,
+            ResamplingFunctionF32::Coalesce => ResamplingFunction::Coalesce,
+            ResamplingFunctionF32::Count => ResamplingFunction::Count,
+        }
+    }
+}
+
+/// Resamples a list of timestamp/value pairs in a single call.
+///
+/// This is a convenience function for one-shot resampling without needing to
+/// manage a `Resampler` instance.
+///
+/// Args:
+///     data: A list of (timestamp, value) tuples to resample. Must be sorted by timestamp.
+///     interval: The resampling interval.
+///     method: The resampling function to use for aggregating values within each interval.
+///     first_timestamp: If True, output timestamps are set to the start of each interval.
+///         If False, output timestamps are set to the end of each interval. Defaults to True.
+///
+/// Returns:
+///     A list of (timestamp, value) tuples representing the resampled data.
+#[pyfunction]
+#[pyo3(signature = (data, interval, method, *, first_timestamp=true))]
+fn resample(
+    data: Vec<(DateTime<Utc>, Option<f32>)>,
+    interval: TimeDelta,
+    method: ResamplingFunctionF32,
+    first_timestamp: bool,
+) -> PyResult<Vec<(DateTime<Utc>, Option<f32>)>> {
+    // Convert f32 to f64 for the Rust implementation
+    let data_f64: Vec<(DateTime<Utc>, Option<f64>)> = data
+        .into_iter()
+        .map(|(ts, val)| (ts, val.map(|v| v as f64)))
+        .collect();
+
+    // Call the Rust implementation
+    let result = crate::resample(&data_f64, interval, method.into(), first_timestamp);
+
+    // Convert f64 back to f32
+    Ok(result
+        .into_iter()
+        .map(|(ts, val)| (ts, val.map(|v| v as f32)))
+        .collect())
+}
+
 /// The Resampler class for f32 values.
 #[pyclass(name = "Resampler")]
 struct ResamplerF32 {
@@ -208,5 +261,6 @@ impl ResamplerF32 {
 fn _rust_backend(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ResamplerF32>()?;
     m.add_class::<ResamplingFunctionF32>()?;
+    m.add_function(wrap_pyfunction!(resample, m)?)?;
     Ok(())
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -174,23 +174,169 @@ impl From<ResamplingFunctionF32> for ResamplingFunction<f64, crate::SimpleSample
     }
 }
 
-fn parse_label(label: &str) -> PyResult<Label> {
-    match label {
-        "left" => Ok(Label::Left),
-        "right" => Ok(Label::Right),
-        _ => Err(PyValueError::new_err(
-            "Invalid label, expected 'left' or 'right'",
-        )),
+#[pyclass(eq, eq_int, name = "Closed")]
+#[derive(Clone, Debug, Copy, PartialEq)]
+enum ClosedPy {
+    Left,
+    Right,
+}
+
+#[pymethods]
+impl ClosedPy {
+    #[new]
+    fn new(value: i32) -> PyResult<Self> {
+        value.try_into()
+    }
+
+    #[staticmethod]
+    fn values() -> Vec<i32> {
+        vec![Self::Left.value(), Self::Right.value()]
+    }
+
+    #[staticmethod]
+    fn members() -> Vec<(String, i32)> {
+        vec![
+            (Self::Left.to_string(), Self::Left.value()),
+            (Self::Right.to_string(), Self::Right.value()),
+        ]
+    }
+
+    fn __str__(&self) -> String {
+        format!("{}.{}", "Closed", self)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("<{}: {}>", self.__str__(), self.value())
+    }
+
+    #[getter]
+    fn name(&self) -> String {
+        self.to_string()
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Left => 0,
+            Self::Right => 1,
+        }
     }
 }
 
-fn parse_closed(closed: &str) -> PyResult<Closed> {
-    match closed {
-        "left" => Ok(Closed::Left),
-        "right" => Ok(Closed::Right),
-        _ => Err(PyValueError::new_err(
-            "Invalid closed value, expected 'left' or 'right'",
-        )),
+impl TryFrom<i32> for ClosedPy {
+    type Error = PyErr;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Left),
+            1 => Ok(Self::Right),
+            _ => Err(PyValueError::new_err("Invalid closed value")),
+        }
+    }
+}
+
+impl Display for ClosedPy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ClosedPy::Left => "Left",
+                ClosedPy::Right => "Right",
+            }
+        )
+    }
+}
+
+impl From<ClosedPy> for Closed {
+    fn from(closed: ClosedPy) -> Self {
+        match closed {
+            ClosedPy::Left => Closed::Left,
+            ClosedPy::Right => Closed::Right,
+        }
+    }
+}
+
+#[pyclass(eq, eq_int, name = "Label")]
+#[derive(Clone, Debug, Copy, PartialEq)]
+enum LabelPy {
+    Left,
+    Right,
+}
+
+#[pymethods]
+impl LabelPy {
+    #[new]
+    fn new(value: i32) -> PyResult<Self> {
+        value.try_into()
+    }
+
+    #[staticmethod]
+    fn values() -> Vec<i32> {
+        vec![Self::Left.value(), Self::Right.value()]
+    }
+
+    #[staticmethod]
+    fn members() -> Vec<(String, i32)> {
+        vec![
+            (Self::Left.to_string(), Self::Left.value()),
+            (Self::Right.to_string(), Self::Right.value()),
+        ]
+    }
+
+    fn __str__(&self) -> String {
+        format!("{}.{}", "Label", self)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("<{}: {}>", self.__str__(), self.value())
+    }
+
+    #[getter]
+    fn name(&self) -> String {
+        self.to_string()
+    }
+
+    #[getter]
+    fn value(&self) -> i32 {
+        match self {
+            Self::Left => 0,
+            Self::Right => 1,
+        }
+    }
+}
+
+impl TryFrom<i32> for LabelPy {
+    type Error = PyErr;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Left),
+            1 => Ok(Self::Right),
+            _ => Err(PyValueError::new_err("Invalid label")),
+        }
+    }
+}
+
+impl Display for LabelPy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                LabelPy::Left => "Left",
+                LabelPy::Right => "Right",
+            }
+        )
+    }
+}
+
+impl From<LabelPy> for Label {
+    fn from(label: LabelPy) -> Self {
+        match label {
+            LabelPy::Left => Label::Left,
+            LabelPy::Right => Label::Right,
+        }
     }
 }
 
@@ -203,11 +349,8 @@ fn parse_closed(closed: &str) -> PyResult<Closed> {
 ///     data: A list of (timestamp, value) tuples to resample. Must be sorted by timestamp.
 ///     interval: The resampling interval.
 ///     method: The resampling function to use for aggregating values within each interval.
-///     closed: Which interval edge is closed for sample membership. Use
-///         `"left"` for `[start, end)` intervals or `"right"` for
-///         `(start, end]` intervals.
-///     label: Which interval edge to use for output timestamps. Use `"left"`
-///         for the interval start or `"right"` for the interval end.
+///     closed: Which interval edge is closed for sample membership.
+///     label: Which interval edge to use for output timestamps.
 ///
 /// Returns:
 ///     A list of (timestamp, value) tuples representing the resampled data.
@@ -217,8 +360,8 @@ fn resample(
     data: Vec<(DateTime<Utc>, Option<f32>)>,
     interval: TimeDelta,
     method: ResamplingFunctionF32,
-    closed: &str,
-    label: &str,
+    closed: ClosedPy,
+    label: LabelPy,
 ) -> PyResult<Vec<(DateTime<Utc>, Option<f32>)>> {
     // Convert f32 to f64 for the Rust implementation
     let data_f64: Vec<(DateTime<Utc>, Option<f64>)> = data
@@ -231,8 +374,8 @@ fn resample(
         &data_f64,
         interval,
         method.into(),
-        parse_closed(closed)?,
-        parse_label(label)?,
+        closed.into(),
+        label.into(),
     );
 
     // Convert f64 back to f32
@@ -257,8 +400,8 @@ impl ResamplerF32 {
         resampling_function: ResamplingFunctionF32,
         max_age_in_intervals: i32,
         start: DateTime<Utc>,
-        closed: &str,
-        label: &str,
+        closed: ClosedPy,
+        label: LabelPy,
     ) -> PyResult<Self> {
         Ok(Self {
             inner: Resampler::new(
@@ -266,8 +409,8 @@ impl ResamplerF32 {
                 resampling_function.into(),
                 max_age_in_intervals,
                 start,
-                parse_closed(closed)?,
-                parse_label(label)?,
+                closed.into(),
+                label.into(),
             ),
         })
     }
@@ -293,6 +436,8 @@ impl ResamplerF32 {
 fn _rust_backend(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ResamplerF32>()?;
     m.add_class::<ResamplingFunctionF32>()?;
+    m.add_class::<ClosedPy>()?;
+    m.add_class::<LabelPy>()?;
     m.add_function(wrap_pyfunction!(resample, m)?)?;
     Ok(())
 }

--- a/src/resampler.rs
+++ b/src/resampler.rs
@@ -242,7 +242,7 @@ impl<
 }
 
 /// Aligns a timestamp to the epoch of the resampling interval.
-pub(crate) fn epoch_align(
+pub fn epoch_align(
     interval: TimeDelta,
     timestamp: DateTime<Utc>,
     alignment_timestamp: Option<DateTime<Utc>>,

--- a/src/resampler.rs
+++ b/src/resampler.rs
@@ -203,8 +203,7 @@ impl<
             let input_interval = self.input_interval.unwrap_or(self.interval);
             let drain_end_date =
                 self.start + self.interval - input_interval * self.max_age_in_intervals;
-            interval_buffer
-                .retain(|s| is_right_of_buffer_edge(&s.timestamp(), &drain_end_date));
+            interval_buffer.retain(|s| is_right_of_buffer_edge(&s.timestamp(), &drain_end_date));
 
             // resample the interval_buffer
             res.push(Sample::new(

--- a/src/resampler.rs
+++ b/src/resampler.rs
@@ -12,6 +12,26 @@ use num_traits::FromPrimitive;
 use std::fmt::Debug;
 use std::ops::Div;
 
+/// Controls which edge of an interval is used as the output timestamp label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Label {
+    /// Label each bucket with its left edge, i.e. the interval start.
+    #[default]
+    Left,
+    /// Label each bucket with its right edge, i.e. the interval end.
+    Right,
+}
+
+/// Controls which edge of an interval is closed for sample membership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Closed {
+    /// Intervals are left-closed and right-open, i.e. `[start, end)`.
+    #[default]
+    Left,
+    /// Intervals are left-open and right-closed, i.e. `(start, end]`.
+    Right,
+}
+
 /// The Sample trait represents a single sample in a time series.
 pub trait Sample: Clone + Debug + Default {
     type Value;
@@ -104,21 +124,23 @@ pub struct Resampler<
     input_start: Option<DateTime<Utc>>,
     /// The interval between the first and the second sample in the buffer
     input_interval: Option<TimeDelta>,
+    /// Controls which edge of an interval is closed for sample membership.
+    closed: Closed,
     /// Controls the output timestamp labeling for resampled samples.
     ///
     /// This parameter only affects how output timestamps are labeled, not how
-    /// samples are grouped into intervals. Intervals are always `[start, end)`.
+    /// samples are grouped into intervals.
     ///
-    /// - If `first_timestamp` is `true`, the output timestamp is set to the
+    /// - If `label` is [`Label::Left`], the output timestamp is set to the
     ///   start of the interval.
-    /// - If `first_timestamp` is `false`, the output timestamp is set to the
+    /// - If `label` is [`Label::Right`], the output timestamp is set to the
     ///   end of the interval.
     ///
     /// For example, with an interval of 5 seconds starting at t=0:
     /// - Interval `[0, 5)` contains samples with timestamps 0, 1, 2, 3, 4
-    /// - If `first_timestamp=true`: output timestamp = 0
-    /// - If `first_timestamp=false`: output timestamp = 5
-    first_timestamp: bool,
+    /// - If `label=Label::Left`: output timestamp = 0
+    /// - If `label=Label::Right`: output timestamp = 5
+    label: Label,
 }
 
 impl<
@@ -133,7 +155,8 @@ impl<
         resampling_function: ResamplingFunction<T, S>,
         max_age_in_intervals: i32,
         start: DateTime<Utc>,
-        first_timestamp: bool,
+        closed: Closed,
+        label: Label,
     ) -> Self {
         let aligned_start = epoch_align(interval, start, None);
         Self {
@@ -141,7 +164,8 @@ impl<
             resampling_function,
             max_age_in_intervals,
             start: aligned_start,
-            first_timestamp,
+            closed,
+            label,
             ..Default::default()
         }
     }
@@ -168,17 +192,23 @@ impl<
         let mut buffer_iter = self.buffer.iter();
         let mut next_sample: Option<&S> = buffer_iter.next();
         self.input_start = next_sample.map(|s| s.timestamp());
-        let offset = if self.first_timestamp {
-            TimeDelta::zero()
-        } else {
-            self.interval
+        let offset = match self.label {
+            Label::Left => TimeDelta::zero(),
+            Label::Right => self.interval,
         };
 
         // loop over the intervals
         while self.start < end {
             // loop over the samples in the buffer
             while next_sample
-                .map(|s| is_left_of_buffer_edge(&s.timestamp(), &(self.start + self.interval)))
+                .map(|s| {
+                    is_in_interval(
+                        &s.timestamp(),
+                        &self.start,
+                        &(self.start + self.interval),
+                        self.closed,
+                    )
+                })
                 .unwrap_or(false)
             {
                 // next sample is not newer than the current interval
@@ -203,7 +233,9 @@ impl<
             let input_interval = self.input_interval.unwrap_or(self.interval);
             let drain_end_date =
                 self.start + self.interval - input_interval * self.max_age_in_intervals;
-            interval_buffer.retain(|s| is_right_of_buffer_edge(&s.timestamp(), &drain_end_date));
+            interval_buffer.retain(|s| {
+                is_after_retention_edge(&s.timestamp(), &drain_end_date, self.closed)
+            });
 
             // resample the interval_buffer
             res.push(Sample::new(
@@ -219,7 +251,7 @@ impl<
         let interval = self.input_interval.unwrap_or(self.interval);
         let drain_end_date = end - interval * self.max_age_in_intervals;
         self.buffer
-            .retain(|s| is_right_of_buffer_edge(&s.timestamp(), &drain_end_date));
+            .retain(|s| is_after_retention_edge(&s.timestamp(), &drain_end_date, self.closed));
 
         res
     }
@@ -255,16 +287,27 @@ pub fn epoch_align(
     .unwrap_or(timestamp)
 }
 
-/// Checks if a timestamp is within the interval for aggregation.
-/// Uses exclusive upper bound: sample is included if timestamp < edge.
-/// This creates intervals of the form [start, end).
-fn is_left_of_buffer_edge(timestamp: &DateTime<Utc>, edge_timestamp: &DateTime<Utc>) -> bool {
-    timestamp < edge_timestamp
+/// Checks whether a timestamp belongs to the current interval.
+fn is_in_interval(
+    timestamp: &DateTime<Utc>,
+    _start: &DateTime<Utc>,
+    end: &DateTime<Utc>,
+    closed: Closed,
+) -> bool {
+    match closed {
+        Closed::Left => timestamp < end,
+        Closed::Right => timestamp <= end,
+    }
 }
 
 /// Checks if a timestamp should be retained in the buffer.
-/// Uses inclusive lower bound: sample is retained if timestamp >= edge.
-/// This creates intervals of the form [start, end).
-fn is_right_of_buffer_edge(timestamp: &DateTime<Utc>, edge_timestamp: &DateTime<Utc>) -> bool {
-    timestamp >= edge_timestamp
+fn is_after_retention_edge(
+    timestamp: &DateTime<Utc>,
+    edge_timestamp: &DateTime<Utc>,
+    closed: Closed,
+) -> bool {
+    match closed {
+        Closed::Left => timestamp >= edge_timestamp,
+        Closed::Right => timestamp > edge_timestamp,
+    }
 }

--- a/src/resampler.rs
+++ b/src/resampler.rs
@@ -233,9 +233,8 @@ impl<
             let input_interval = self.input_interval.unwrap_or(self.interval);
             let drain_end_date =
                 self.start + self.interval - input_interval * self.max_age_in_intervals;
-            interval_buffer.retain(|s| {
-                is_after_retention_edge(&s.timestamp(), &drain_end_date, self.closed)
-            });
+            interval_buffer
+                .retain(|s| is_after_retention_edge(&s.timestamp(), &drain_end_date, self.closed));
 
             // resample the interval_buffer
             res.push(Sample::new(

--- a/src/resampler.rs
+++ b/src/resampler.rs
@@ -104,15 +104,20 @@ pub struct Resampler<
     input_start: Option<DateTime<Utc>>,
     /// The interval between the first and the second sample in the buffer
     input_interval: Option<TimeDelta>,
-    /// Whether the resampled timestamp should be the first timestamp (if
-    /// `first_timestamp` is `true`) or the last timestamp (if
-    /// `first_timestamp` is `false`) in the buffer.
-    /// If `first_timestamp` is `true`, the resampled timestamp will be the
-    /// timestamp of the first sample in the buffer and the aggregation will
-    /// be done with the samples that are `interval` in the future.
-    /// If `first_timestamp` is `false`, the resampled timestamp will be the
-    /// timestamp of the last sample in the buffer and the aggregation will
-    /// be done with the samples that are `interval` in the past.
+    /// Controls the output timestamp labeling for resampled samples.
+    ///
+    /// This parameter only affects how output timestamps are labeled, not how
+    /// samples are grouped into intervals. Intervals are always `[start, end)`.
+    ///
+    /// - If `first_timestamp` is `true`, the output timestamp is set to the
+    ///   start of the interval.
+    /// - If `first_timestamp` is `false`, the output timestamp is set to the
+    ///   end of the interval.
+    ///
+    /// For example, with an interval of 5 seconds starting at t=0:
+    /// - Interval `[0, 5)` contains samples with timestamps 0, 1, 2, 3, 4
+    /// - If `first_timestamp=true`: output timestamp = 0
+    /// - If `first_timestamp=false`: output timestamp = 5
     first_timestamp: bool,
 }
 
@@ -173,13 +178,7 @@ impl<
         while self.start < end {
             // loop over the samples in the buffer
             while next_sample
-                .map(|s| {
-                    is_left_of_buffer_edge(
-                        self.first_timestamp,
-                        &s.timestamp(),
-                        &(self.start + self.interval),
-                    )
-                })
+                .map(|s| is_left_of_buffer_edge(&s.timestamp(), &(self.start + self.interval)))
                 .unwrap_or(false)
             {
                 // next sample is not newer than the current interval
@@ -204,9 +203,8 @@ impl<
             let input_interval = self.input_interval.unwrap_or(self.interval);
             let drain_end_date =
                 self.start + self.interval - input_interval * self.max_age_in_intervals;
-            interval_buffer.retain(|s| {
-                is_right_of_buffer_edge(self.first_timestamp, &s.timestamp(), &drain_end_date)
-            });
+            interval_buffer
+                .retain(|s| is_right_of_buffer_edge(&s.timestamp(), &drain_end_date));
 
             // resample the interval_buffer
             res.push(Sample::new(
@@ -221,9 +219,8 @@ impl<
         // Remove samples from buffer that are older than max_age
         let interval = self.input_interval.unwrap_or(self.interval);
         let drain_end_date = end - interval * self.max_age_in_intervals;
-        self.buffer.retain(|s| {
-            is_right_of_buffer_edge(self.first_timestamp, &s.timestamp(), &drain_end_date)
-        });
+        self.buffer
+            .retain(|s| is_right_of_buffer_edge(&s.timestamp(), &drain_end_date));
 
         res
     }
@@ -259,26 +256,16 @@ pub(crate) fn epoch_align(
     .unwrap_or(timestamp)
 }
 
-fn is_left_of_buffer_edge(
-    first_timestamp: bool,
-    timestamp: &DateTime<Utc>,
-    edge_timestamp: &DateTime<Utc>,
-) -> bool {
-    if first_timestamp {
-        timestamp < edge_timestamp
-    } else {
-        timestamp <= edge_timestamp
-    }
+/// Checks if a timestamp is within the interval for aggregation.
+/// Uses exclusive upper bound: sample is included if timestamp < edge.
+/// This creates intervals of the form [start, end).
+fn is_left_of_buffer_edge(timestamp: &DateTime<Utc>, edge_timestamp: &DateTime<Utc>) -> bool {
+    timestamp < edge_timestamp
 }
 
-fn is_right_of_buffer_edge(
-    first_timestamp: bool,
-    timestamp: &DateTime<Utc>,
-    edge_timestamp: &DateTime<Utc>,
-) -> bool {
-    if first_timestamp {
-        timestamp >= edge_timestamp
-    } else {
-        timestamp > edge_timestamp
-    }
+/// Checks if a timestamp should be retained in the buffer.
+/// Uses inclusive lower bound: sample is retained if timestamp >= edge.
+/// This creates intervals of the form [start, end).
+fn is_right_of_buffer_edge(timestamp: &DateTime<Utc>, edge_timestamp: &DateTime<Utc>) -> bool {
+    timestamp >= edge_timestamp
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::resampler::{epoch_align, Resampler, Sample};
-use crate::ResamplingFunction;
+use crate::{resample, ResamplingFunction};
 use chrono::{DateTime, TimeDelta, Utc};
 use num_traits::FromPrimitive;
 
@@ -1079,4 +1079,189 @@ fn test_resampling_non_primitive_sum() {
         ),
     ];
     assert_eq!(resampled, expected);
+}
+
+// Tests for the one-shot resample function
+
+#[test]
+fn test_resample_function_basic() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+
+    // Data: t=0,1,2,3,4,5,6,7,8,9 with values 1-10
+    // Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → avg = 3.0
+    // Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → avg = 8.0
+    let data: Vec<(DateTime<Utc>, Option<f64>)> = (0..10)
+        .map(|i| (start + step * i, Some((i + 1) as f64)))
+        .collect();
+
+    let result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        true,
+    );
+
+    assert_eq!(result.len(), 2);
+    assert_eq!(
+        result[0],
+        (DateTime::from_timestamp(0, 0).unwrap(), Some(3.0))
+    );
+    assert_eq!(
+        result[1],
+        (DateTime::from_timestamp(5, 0).unwrap(), Some(8.0))
+    );
+}
+
+#[test]
+fn test_resample_function_first_timestamp_false() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+
+    let data: Vec<(DateTime<Utc>, Option<f64>)> = (0..10)
+        .map(|i| (start + step * i, Some((i + 1) as f64)))
+        .collect();
+
+    let result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        false,
+    );
+
+    assert_eq!(result.len(), 2);
+    // With first_timestamp=false, timestamps are at end of interval
+    assert_eq!(
+        result[0],
+        (DateTime::from_timestamp(5, 0).unwrap(), Some(3.0))
+    );
+    assert_eq!(
+        result[1],
+        (DateTime::from_timestamp(10, 0).unwrap(), Some(8.0))
+    );
+}
+
+#[test]
+fn test_resample_function_empty_data() {
+    let data: Vec<(DateTime<Utc>, Option<f64>)> = vec![];
+
+    let result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        true,
+    );
+
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_resample_function_with_none_values() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+
+    // First value in each interval is None
+    let data: Vec<(DateTime<Utc>, Option<f64>)> = (0..10)
+        .map(|i| {
+            let value = if i == 0 || i == 5 {
+                None
+            } else {
+                Some((i + 1) as f64)
+            };
+            (start + step * i, value)
+        })
+        .collect();
+
+    let result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        true,
+    );
+
+    assert_eq!(result.len(), 2);
+    // Interval [0, 5): values 2,3,4,5 → avg = 3.5
+    // Interval [5, 10): values 7,8,9,10 → avg = 8.5
+    assert_eq!(
+        result[0],
+        (DateTime::from_timestamp(0, 0).unwrap(), Some(3.5))
+    );
+    assert_eq!(
+        result[1],
+        (DateTime::from_timestamp(5, 0).unwrap(), Some(8.5))
+    );
+}
+
+#[test]
+fn test_resample_function_sum() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+
+    let data: Vec<(DateTime<Utc>, Option<f64>)> = (0..10)
+        .map(|i| (start + step * i, Some((i + 1) as f64)))
+        .collect();
+
+    let result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Sum, true);
+
+    assert_eq!(result.len(), 2);
+    // Interval [0, 5): sum(1,2,3,4,5) = 15.0
+    // Interval [5, 10): sum(6,7,8,9,10) = 40.0
+    assert_eq!(
+        result[0],
+        (DateTime::from_timestamp(0, 0).unwrap(), Some(15.0))
+    );
+    assert_eq!(
+        result[1],
+        (DateTime::from_timestamp(5, 0).unwrap(), Some(40.0))
+    );
+}
+
+#[test]
+fn test_resample_function_min_max() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+
+    let data: Vec<(DateTime<Utc>, Option<f64>)> = (0..10)
+        .map(|i| (start + step * i, Some((i + 1) as f64)))
+        .collect();
+
+    let min_result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Min, true);
+    let max_result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Max, true);
+
+    assert_eq!(
+        min_result[0],
+        (DateTime::from_timestamp(0, 0).unwrap(), Some(1.0))
+    );
+    assert_eq!(
+        min_result[1],
+        (DateTime::from_timestamp(5, 0).unwrap(), Some(6.0))
+    );
+    assert_eq!(
+        max_result[0],
+        (DateTime::from_timestamp(0, 0).unwrap(), Some(5.0))
+    );
+    assert_eq!(
+        max_result[1],
+        (DateTime::from_timestamp(5, 0).unwrap(), Some(10.0))
+    );
+}
+
+#[test]
+fn test_resample_function_single_sample() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+
+    let data: Vec<(DateTime<Utc>, Option<f64>)> = vec![(start, Some(42.0))];
+
+    let result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        true,
+    );
+
+    assert_eq!(result.len(), 1);
+    assert_eq!(
+        result[0],
+        (DateTime::from_timestamp(0, 0).unwrap(), Some(42.0))
+    );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,17 +44,20 @@ fn test_resampling(
     let mut resampler: Resampler<f64, TestSample> =
         Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
     let step = TimeDelta::seconds(1);
+    // Data starts at t=0, matching the README example
+    // Interval [0, 5) contains t=0,1,2,3,4 with values 1,2,3,4,5
+    // Interval [5, 10) contains t=5,6,7,8,9 with values 6,7,8,9,10
     let data = vec![
-        TestSample::new(start + step, Some(1.0)),
-        TestSample::new(start + step * 2, Some(2.0)),
-        TestSample::new(start + step * 3, Some(3.0)),
-        TestSample::new(start + step * 4, Some(4.0)),
-        TestSample::new(start + step * 5, Some(5.0)),
-        TestSample::new(start + step * 6, Some(6.0)),
-        TestSample::new(start + step * 7, Some(7.0)),
-        TestSample::new(start + step * 8, Some(8.0)),
-        TestSample::new(start + step * 9, Some(9.0)),
-        TestSample::new(start + step * 10, Some(10.0)),
+        TestSample::new(start, Some(1.0)),
+        TestSample::new(start + step, Some(2.0)),
+        TestSample::new(start + step * 2, Some(3.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 5, Some(6.0)),
+        TestSample::new(start + step * 6, Some(7.0)),
+        TestSample::new(start + step * 7, Some(8.0)),
+        TestSample::new(start + step * 8, Some(9.0)),
+        TestSample::new(start + step * 9, Some(10.0)),
     ];
 
     resampler.extend(data);
@@ -71,17 +74,20 @@ fn test_resampling_with_none_first(
     let mut resampler: Resampler<f64, TestSample> =
         Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
     let step = TimeDelta::seconds(1);
+    // First sample at t=0 is None
+    // Interval [0, 5) contains t=0,1,2,3,4 with values None,2,3,4,5
+    // Interval [5, 10) contains t=5,6,7,8,9 with values None,7,8,9,10
     let data = vec![
-        TestSample::new(start + step, None),
-        TestSample::new(start + step * 2, Some(2.0)),
-        TestSample::new(start + step * 3, Some(3.0)),
-        TestSample::new(start + step * 4, Some(4.0)),
-        TestSample::new(start + step * 5, Some(5.0)),
-        TestSample::new(start + step * 6, None),
-        TestSample::new(start + step * 7, Some(7.0)),
-        TestSample::new(start + step * 8, Some(8.0)),
-        TestSample::new(start + step * 9, Some(9.0)),
-        TestSample::new(start + step * 10, Some(10.0)),
+        TestSample::new(start, None),
+        TestSample::new(start + step, Some(2.0)),
+        TestSample::new(start + step * 2, Some(3.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 5, None),
+        TestSample::new(start + step * 6, Some(7.0)),
+        TestSample::new(start + step * 7, Some(8.0)),
+        TestSample::new(start + step * 8, Some(9.0)),
+        TestSample::new(start + step * 9, Some(10.0)),
     ];
 
     resampler.extend(data);
@@ -98,7 +104,9 @@ fn test_resampling_with_none_all(
     let mut resampler: Resampler<f64, TestSample> =
         Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
     let step = TimeDelta::seconds(1);
+    // All values are None
     let data = vec![
+        TestSample::new(start, None),
         TestSample::new(start + step, None),
         TestSample::new(start + step * 2, None),
         TestSample::new(start + step * 3, None),
@@ -108,7 +116,6 @@ fn test_resampling_with_none_all(
         TestSample::new(start + step * 7, None),
         TestSample::new(start + step * 8, None),
         TestSample::new(start + step * 9, None),
-        TestSample::new(start + step * 10, None),
     ];
 
     resampler.extend(data);
@@ -377,22 +384,23 @@ fn test_resampling_with_max_age() {
         false,
     );
     let step = TimeDelta::seconds(1);
+    // Data starts at t=0 with values 1-15
     let data = vec![
-        TestSample::new(start + step, Some(1.0)),
-        TestSample::new(start + step * 2, Some(2.0)),
-        TestSample::new(start + step * 3, Some(3.0)),
-        TestSample::new(start + step * 4, Some(4.0)),
-        TestSample::new(start + step * 5, Some(5.0)),
-        TestSample::new(start + step * 6, Some(6.0)),
-        TestSample::new(start + step * 7, Some(7.0)),
-        TestSample::new(start + step * 8, Some(8.0)),
-        TestSample::new(start + step * 9, Some(9.0)),
-        TestSample::new(start + step * 10, Some(10.0)),
-        TestSample::new(start + step * 11, Some(11.0)),
-        TestSample::new(start + step * 12, Some(12.0)),
-        TestSample::new(start + step * 13, Some(13.0)),
-        TestSample::new(start + step * 14, Some(14.0)),
-        TestSample::new(start + step * 15, Some(15.0)),
+        TestSample::new(start, Some(1.0)),
+        TestSample::new(start + step, Some(2.0)),
+        TestSample::new(start + step * 2, Some(3.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 5, Some(6.0)),
+        TestSample::new(start + step * 6, Some(7.0)),
+        TestSample::new(start + step * 7, Some(8.0)),
+        TestSample::new(start + step * 8, Some(9.0)),
+        TestSample::new(start + step * 9, Some(10.0)),
+        TestSample::new(start + step * 10, Some(11.0)),
+        TestSample::new(start + step * 11, Some(12.0)),
+        TestSample::new(start + step * 12, Some(13.0)),
+        TestSample::new(start + step * 13, Some(14.0)),
+        TestSample::new(start + step * 14, Some(15.0)),
     ];
 
     resampler.extend(data);
@@ -459,22 +467,23 @@ fn test_resampling_with_max_age_older() {
         false,
     );
     let step = TimeDelta::seconds(1);
+    // Data starts at t=0 with values 1-15
     let data = vec![
-        TestSample::new(start + step, Some(1.0)),
-        TestSample::new(start + step * 2, Some(2.0)),
-        TestSample::new(start + step * 3, Some(3.0)),
-        TestSample::new(start + step * 4, Some(4.0)),
-        TestSample::new(start + step * 5, Some(5.0)),
-        TestSample::new(start + step * 6, Some(6.0)),
-        TestSample::new(start + step * 7, Some(7.0)),
-        TestSample::new(start + step * 8, Some(8.0)),
-        TestSample::new(start + step * 9, Some(9.0)),
-        TestSample::new(start + step * 10, Some(10.0)),
-        TestSample::new(start + step * 11, Some(11.0)),
-        TestSample::new(start + step * 12, Some(12.0)),
-        TestSample::new(start + step * 13, Some(13.0)),
-        TestSample::new(start + step * 14, Some(14.0)),
-        TestSample::new(start + step * 15, Some(15.0)),
+        TestSample::new(start, Some(1.0)),
+        TestSample::new(start + step, Some(2.0)),
+        TestSample::new(start + step * 2, Some(3.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 5, Some(6.0)),
+        TestSample::new(start + step * 6, Some(7.0)),
+        TestSample::new(start + step * 7, Some(8.0)),
+        TestSample::new(start + step * 8, Some(9.0)),
+        TestSample::new(start + step * 9, Some(10.0)),
+        TestSample::new(start + step * 10, Some(11.0)),
+        TestSample::new(start + step * 11, Some(12.0)),
+        TestSample::new(start + step * 12, Some(13.0)),
+        TestSample::new(start + step * 13, Some(14.0)),
+        TestSample::new(start + step * 14, Some(15.0)),
     ];
 
     resampler.extend(data);
@@ -500,24 +509,25 @@ fn test_resampling_with_max_age_batch() {
         false,
     );
     let step = TimeDelta::seconds(1);
+    // Data starts at t=0 with values 1-10
     let data1 = vec![
-        TestSample::new(start + step * 1, Some(1.0)),
-        TestSample::new(start + step * 2, Some(2.0)),
-        TestSample::new(start + step * 3, Some(3.0)),
-        TestSample::new(start + step * 4, Some(4.0)),
-        TestSample::new(start + step * 5, Some(5.0)),
-        TestSample::new(start + step * 6, Some(6.0)),
-        TestSample::new(start + step * 7, Some(7.0)),
-        TestSample::new(start + step * 8, Some(8.0)),
-        TestSample::new(start + step * 9, Some(9.0)),
-        TestSample::new(start + step * 10, Some(10.0)),
+        TestSample::new(start, Some(1.0)),
+        TestSample::new(start + step, Some(2.0)),
+        TestSample::new(start + step * 2, Some(3.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 5, Some(6.0)),
+        TestSample::new(start + step * 6, Some(7.0)),
+        TestSample::new(start + step * 7, Some(8.0)),
+        TestSample::new(start + step * 8, Some(9.0)),
+        TestSample::new(start + step * 9, Some(10.0)),
     ];
     let data2 = vec![
-        TestSample::new(start + step * 11, Some(11.0)),
-        TestSample::new(start + step * 12, Some(12.0)),
-        TestSample::new(start + step * 13, Some(13.0)),
-        TestSample::new(start + step * 14, Some(14.0)),
-        TestSample::new(start + step * 15, Some(15.0)),
+        TestSample::new(start + step * 10, Some(11.0)),
+        TestSample::new(start + step * 11, Some(12.0)),
+        TestSample::new(start + step * 12, Some(13.0)),
+        TestSample::new(start + step * 13, Some(14.0)),
+        TestSample::new(start + step * 14, Some(15.0)),
     ];
 
     resampler.extend(data1);
@@ -552,13 +562,18 @@ fn test_resampling_with_gap() {
         false,
     );
     let step = TimeDelta::seconds(1);
+    // Data with gaps: samples at t=0,1,3,4, then gap, then t=16,19
+    // Interval [0, 5): t=0,1,3,4 with values 1,2,4,5 → avg = 3.0
+    // Interval [5, 10): none → None
+    // Interval [10, 15): none → None
+    // Interval [15, 20): t=16,19 with values 6,10 → avg = 8.0
     let data = vec![
-        TestSample::new(start + step, Some(1.0)),
-        TestSample::new(start + step * 2, Some(2.0)),
-        TestSample::new(start + step * 4, Some(4.0)),
-        TestSample::new(start + step * 5, Some(5.0)),
-        TestSample::new(start + step * 17, Some(6.0)),
-        TestSample::new(start + step * 20, Some(10.0)),
+        TestSample::new(start, Some(1.0)),
+        TestSample::new(start + step, Some(2.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 16, Some(6.0)),
+        TestSample::new(start + step * 19, Some(10.0)),
     ];
 
     resampler.extend(data);
@@ -621,13 +636,14 @@ fn test_resampling_with_gap_early_end_date() {
         false,
     );
     let step = TimeDelta::seconds(1);
+    // Same data structure as test_resampling_with_gap, but tests batched resampling
     let data = vec![
-        TestSample::new(start + step, Some(1.0)),
-        TestSample::new(start + step * 2, Some(2.0)),
-        TestSample::new(start + step * 4, Some(4.0)),
-        TestSample::new(start + step * 5, Some(5.0)),
-        TestSample::new(start + step * 17, Some(6.0)),
-        TestSample::new(start + step * 20, Some(10.0)),
+        TestSample::new(start, Some(1.0)),
+        TestSample::new(start + step, Some(2.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 16, Some(6.0)),
+        TestSample::new(start + step * 19, Some(10.0)),
     ];
 
     resampler.extend(data);
@@ -689,7 +705,7 @@ fn test_epoch_alignment() {
 }
 
 #[test]
-fn test_is_right_of_buffer_edge() {
+fn test_first_timestamp_true() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let mut resampler: Resampler<f64, TestSample> = Resampler::new(
         TimeDelta::seconds(5),
@@ -715,11 +731,58 @@ fn test_is_right_of_buffer_edge() {
     resampler.extend(data);
 
     let resampled = resampler.resample(start + step * 10);
+    // Intervals: [0, 5) with samples t=0,1,2,3,4 → avg(1,2,3,4,5) = 3.0
+    //            [5, 10) with samples t=5,6,7,8,9 → avg(6,7,8,9,10) = 8.0
+    // Output timestamp is at interval start (first_timestamp=true)
     assert_eq!(
         resampled,
         vec![
             TestSample::new(DateTime::from_timestamp(0, 0).unwrap(), Some(3.0)),
             TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(8.0)),
+        ],
+    );
+}
+
+/// Test that matches the README example exactly.
+/// This test verifies that first_timestamp only affects the output timestamp,
+/// not the interval grouping semantics.
+#[test]
+fn test_first_timestamp_false() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        false,
+    );
+    let step = TimeDelta::seconds(1);
+    let data = vec![
+        TestSample::new(start, Some(1.0)),
+        TestSample::new(start + step * 1, Some(2.0)),
+        TestSample::new(start + step * 2, Some(3.0)),
+        TestSample::new(start + step * 3, Some(4.0)),
+        TestSample::new(start + step * 4, Some(5.0)),
+        TestSample::new(start + step * 5, Some(6.0)),
+        TestSample::new(start + step * 6, Some(7.0)),
+        TestSample::new(start + step * 7, Some(8.0)),
+        TestSample::new(start + step * 8, Some(9.0)),
+        TestSample::new(start + step * 9, Some(10.0)),
+    ];
+
+    resampler.extend(data);
+
+    let resampled = resampler.resample(start + step * 10);
+    // Intervals should be the same as first_timestamp=true: [0, 5) and [5, 10)
+    // Only the output timestamp should differ (end of interval instead of start)
+    // Interval [0, 5) with samples t=0,1,2,3,4 → avg(1,2,3,4,5) = 3.0
+    // Interval [5, 10) with samples t=5,6,7,8,9 → avg(6,7,8,9,10) = 8.0
+    // Output timestamp is at interval end (first_timestamp=false)
+    assert_eq!(
+        resampled,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(3.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(8.0)),
         ],
     );
 }
@@ -818,17 +881,18 @@ fn test_resampling_non_primitive_average() {
         false,
     );
     let step = TimeDelta::seconds(1);
+    // Data starts at t=0
     let data = vec![
-        NonPrimitiveSample::new(start + step, Some(NonPrimitive { value: vec![1] })),
-        NonPrimitiveSample::new(start + step * 2, Some(NonPrimitive { value: vec![2] })),
-        NonPrimitiveSample::new(start + step * 3, Some(NonPrimitive { value: vec![3] })),
-        NonPrimitiveSample::new(start + step * 4, Some(NonPrimitive { value: vec![4] })),
-        NonPrimitiveSample::new(start + step * 5, Some(NonPrimitive { value: vec![5] })),
-        NonPrimitiveSample::new(start + step * 6, Some(NonPrimitive { value: vec![6] })),
-        NonPrimitiveSample::new(start + step * 7, Some(NonPrimitive { value: vec![7] })),
-        NonPrimitiveSample::new(start + step * 8, Some(NonPrimitive { value: vec![8] })),
-        NonPrimitiveSample::new(start + step * 9, Some(NonPrimitive { value: vec![9] })),
-        NonPrimitiveSample::new(start + step * 10, Some(NonPrimitive { value: vec![10] })),
+        NonPrimitiveSample::new(start, Some(NonPrimitive { value: vec![1] })),
+        NonPrimitiveSample::new(start + step, Some(NonPrimitive { value: vec![2] })),
+        NonPrimitiveSample::new(start + step * 2, Some(NonPrimitive { value: vec![3] })),
+        NonPrimitiveSample::new(start + step * 3, Some(NonPrimitive { value: vec![4] })),
+        NonPrimitiveSample::new(start + step * 4, Some(NonPrimitive { value: vec![5] })),
+        NonPrimitiveSample::new(start + step * 5, Some(NonPrimitive { value: vec![6] })),
+        NonPrimitiveSample::new(start + step * 6, Some(NonPrimitive { value: vec![7] })),
+        NonPrimitiveSample::new(start + step * 7, Some(NonPrimitive { value: vec![8] })),
+        NonPrimitiveSample::new(start + step * 8, Some(NonPrimitive { value: vec![9] })),
+        NonPrimitiveSample::new(start + step * 9, Some(NonPrimitive { value: vec![10] })),
     ];
 
     resampler.extend(data);
@@ -859,17 +923,20 @@ fn test_resampling_non_primitive_sum() {
         false,
     );
     let step = TimeDelta::seconds(1);
+    // Data starts at t=0
+    // Interval [0, 5): t=0,1,2,3,4 with values [1],[2],[3],[4],[5]
+    // Interval [5, 10): t=5,6,7,8,9 with values [6],[7],[8],[9],[10]
     let data = vec![
-        NonPrimitiveSample::new(start + step, Some(NonPrimitive { value: vec![1] })),
-        NonPrimitiveSample::new(start + step * 2, Some(NonPrimitive { value: vec![2] })),
-        NonPrimitiveSample::new(start + step * 3, Some(NonPrimitive { value: vec![3] })),
-        NonPrimitiveSample::new(start + step * 4, Some(NonPrimitive { value: vec![4] })),
-        NonPrimitiveSample::new(start + step * 5, Some(NonPrimitive { value: vec![5] })),
-        NonPrimitiveSample::new(start + step * 6, Some(NonPrimitive { value: vec![6] })),
-        NonPrimitiveSample::new(start + step * 7, Some(NonPrimitive { value: vec![7] })),
-        NonPrimitiveSample::new(start + step * 8, Some(NonPrimitive { value: vec![8] })),
-        NonPrimitiveSample::new(start + step * 9, Some(NonPrimitive { value: vec![9] })),
-        NonPrimitiveSample::new(start + step * 10, Some(NonPrimitive { value: vec![10] })),
+        NonPrimitiveSample::new(start, Some(NonPrimitive { value: vec![1] })),
+        NonPrimitiveSample::new(start + step, Some(NonPrimitive { value: vec![2] })),
+        NonPrimitiveSample::new(start + step * 2, Some(NonPrimitive { value: vec![3] })),
+        NonPrimitiveSample::new(start + step * 3, Some(NonPrimitive { value: vec![4] })),
+        NonPrimitiveSample::new(start + step * 4, Some(NonPrimitive { value: vec![5] })),
+        NonPrimitiveSample::new(start + step * 5, Some(NonPrimitive { value: vec![6] })),
+        NonPrimitiveSample::new(start + step * 6, Some(NonPrimitive { value: vec![7] })),
+        NonPrimitiveSample::new(start + step * 7, Some(NonPrimitive { value: vec![8] })),
+        NonPrimitiveSample::new(start + step * 8, Some(NonPrimitive { value: vec![9] })),
+        NonPrimitiveSample::new(start + step * 9, Some(NonPrimitive { value: vec![10] })),
     ];
 
     resampler.extend(data);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -41,15 +41,14 @@ fn test_resampling(
     expected: Vec<TestSample>,
 ) {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(
-            TimeDelta::seconds(5),
-            resampling_function,
-            1,
-            start,
-            Closed::Left,
-            Label::Right,
-        );
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        resampling_function,
+        1,
+        start,
+        Closed::Left,
+        Label::Right,
+    );
     let step = TimeDelta::seconds(1);
     // Data starts at t=0, matching the README example
     // Interval [0, 5) contains t=0,1,2,3,4 with values 1,2,3,4,5
@@ -78,15 +77,14 @@ fn test_resampling_with_none_first(
     expected: Vec<TestSample>,
 ) {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(
-            TimeDelta::seconds(5),
-            resampling_function,
-            1,
-            start,
-            Closed::Left,
-            Label::Right,
-        );
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        resampling_function,
+        1,
+        start,
+        Closed::Left,
+        Label::Right,
+    );
     let step = TimeDelta::seconds(1);
     // First sample at t=0 is None
     // Interval [0, 5) contains t=0,1,2,3,4 with values None,2,3,4,5
@@ -115,15 +113,14 @@ fn test_resampling_with_none_all(
     expected: Vec<TestSample>,
 ) {
     let start = DateTime::from_timestamp(0, 0).unwrap();
-    let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(
-            TimeDelta::seconds(5),
-            resampling_function,
-            1,
-            start,
-            Closed::Left,
-            Label::Right,
-        );
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        resampling_function,
+        1,
+        start,
+        Closed::Left,
+        Label::Right,
+    );
     let step = TimeDelta::seconds(1);
     // All values are None
     let data = vec![
@@ -1211,6 +1208,29 @@ fn test_resample_function_label_right() {
     assert_eq!(
         result[1],
         (DateTime::from_timestamp(10, 0).unwrap(), Some(8.0))
+    );
+}
+
+#[test]
+fn test_resample_function_closed_right() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+    let data = vec![(start, Some(10.0)), (start + step * 5, Some(20.0))];
+
+    let result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Sum,
+        Closed::Right,
+        Label::Right,
+    );
+
+    assert_eq!(
+        result,
+        vec![
+            (DateTime::from_timestamp(0, 0).unwrap(), Some(10.0)),
+            (DateTime::from_timestamp(5, 0).unwrap(), Some(20.0)),
+        ]
     );
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -743,6 +743,127 @@ fn test_first_timestamp_true() {
     );
 }
 
+/// Test that first_timestamp only affects output timestamps, not aggregated values.
+/// Both resamplers should produce the same values, just with different timestamps.
+#[test]
+fn test_first_timestamp_same_values() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+    let data: Vec<TestSample> = (0..10)
+        .map(|i| TestSample::new(start + step * i, Some((i + 1) as f64)))
+        .collect();
+
+    let mut resampler_true: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        true,
+    );
+    let mut resampler_false: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        false,
+    );
+
+    resampler_true.extend(data.clone());
+    resampler_false.extend(data);
+
+    let result_true = resampler_true.resample(start + step * 10);
+    let result_false = resampler_false.resample(start + step * 10);
+
+    // Both should have same number of results
+    assert_eq!(result_true.len(), result_false.len());
+
+    // Values should be identical, only timestamps differ
+    for (r_true, r_false) in result_true.iter().zip(result_false.iter()) {
+        assert_eq!(r_true.value(), r_false.value());
+        // Timestamps differ by exactly one interval (5 seconds)
+        assert_eq!(
+            r_false.timestamp() - r_true.timestamp(),
+            TimeDelta::seconds(5)
+        );
+    }
+}
+
+/// Test that a sample exactly at interval boundary goes to the next interval.
+/// With [start, end) semantics, sample at t=5 should be in interval [5, 10), not [0, 5).
+#[test]
+fn test_sample_at_interval_boundary() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Sum,
+        1,
+        start,
+        false,
+    );
+
+    // Only add samples at boundaries: t=0, t=5
+    let data = vec![
+        TestSample::new(start, Some(10.0)),            // t=0, in [0, 5)
+        TestSample::new(start + step * 5, Some(20.0)), // t=5, in [5, 10)
+    ];
+
+    resampler.extend(data);
+
+    let resampled = resampler.resample(start + step * 10);
+
+    // Interval [0, 5): only t=0 → sum = 10.0
+    // Interval [5, 10): only t=5 → sum = 20.0
+    assert_eq!(
+        resampled,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(10.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(20.0)),
+        ],
+    );
+}
+
+/// Test with data starting mid-interval.
+/// Verifies correct behavior when first sample doesn't align with interval start.
+#[test]
+fn test_data_starting_mid_interval() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Average,
+        1,
+        start,
+        false,
+    );
+
+    // Data starts at t=2, not t=0
+    // Interval [0, 5): samples at t=2,3,4 with values 1,2,3 → avg = 2.0
+    // Interval [5, 10): samples at t=5,6,7 with values 4,5,6 → avg = 5.0
+    let data = vec![
+        TestSample::new(start + step * 2, Some(1.0)),
+        TestSample::new(start + step * 3, Some(2.0)),
+        TestSample::new(start + step * 4, Some(3.0)),
+        TestSample::new(start + step * 5, Some(4.0)),
+        TestSample::new(start + step * 6, Some(5.0)),
+        TestSample::new(start + step * 7, Some(6.0)),
+    ];
+
+    resampler.extend(data);
+
+    let resampled = resampler.resample(start + step * 10);
+
+    assert_eq!(
+        resampled,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(2.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), Some(5.0)),
+        ],
+    );
+}
+
 /// Test that matches the README example exactly.
 /// This test verifies that first_timestamp only affects the output timestamp,
 /// not the interval grouping semantics.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use crate::resampler::{epoch_align, Resampler, Sample};
-use crate::{resample, ResamplingFunction};
+use crate::{resample, Closed, Label, ResamplingFunction};
 use chrono::{DateTime, TimeDelta, Utc};
 use num_traits::FromPrimitive;
 
@@ -42,7 +42,14 @@ fn test_resampling(
 ) {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
+        Resampler::new(
+            TimeDelta::seconds(5),
+            resampling_function,
+            1,
+            start,
+            Closed::Left,
+            Label::Right,
+        );
     let step = TimeDelta::seconds(1);
     // Data starts at t=0, matching the README example
     // Interval [0, 5) contains t=0,1,2,3,4 with values 1,2,3,4,5
@@ -72,7 +79,14 @@ fn test_resampling_with_none_first(
 ) {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
+        Resampler::new(
+            TimeDelta::seconds(5),
+            resampling_function,
+            1,
+            start,
+            Closed::Left,
+            Label::Right,
+        );
     let step = TimeDelta::seconds(1);
     // First sample at t=0 is None
     // Interval [0, 5) contains t=0,1,2,3,4 with values None,2,3,4,5
@@ -102,7 +116,14 @@ fn test_resampling_with_none_all(
 ) {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let mut resampler: Resampler<f64, TestSample> =
-        Resampler::new(TimeDelta::seconds(5), resampling_function, 1, start, false);
+        Resampler::new(
+            TimeDelta::seconds(5),
+            resampling_function,
+            1,
+            start,
+            Closed::Left,
+            Label::Right,
+        );
     let step = TimeDelta::seconds(1);
     // All values are None
     let data = vec![
@@ -381,7 +402,8 @@ fn test_resampling_with_max_age() {
         ResamplingFunction::Average,
         2,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     // Data starts at t=0 with values 1-15
@@ -423,7 +445,8 @@ fn test_resampling_with_zero_max_age() {
         ResamplingFunction::Average,
         0,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     let data = vec![
@@ -464,7 +487,8 @@ fn test_resampling_with_max_age_older() {
         ResamplingFunction::Average,
         3,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     // Data starts at t=0 with values 1-15
@@ -506,7 +530,8 @@ fn test_resampling_with_max_age_batch() {
         ResamplingFunction::Average,
         2,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     // Data starts at t=0 with values 1-10
@@ -559,7 +584,8 @@ fn test_resampling_with_gap() {
         ResamplingFunction::Average,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     // Data with gaps: samples at t=0,1,3,4, then gap, then t=16,19
@@ -597,7 +623,8 @@ fn test_resampling_with_slow_data() {
         ResamplingFunction::Average,
         2,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let offset = TimeDelta::milliseconds(500);
     let step = TimeDelta::seconds(2);
@@ -633,7 +660,8 @@ fn test_resampling_with_gap_early_end_date() {
         ResamplingFunction::Average,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     // Same data structure as test_resampling_with_gap, but tests batched resampling
@@ -673,7 +701,8 @@ fn test_empty_buffer() {
         ResamplingFunction::Average,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
 
     let resampled = resampler.resample(start + TimeDelta::seconds(10));
@@ -705,14 +734,15 @@ fn test_epoch_alignment() {
 }
 
 #[test]
-fn test_first_timestamp_true() {
+fn test_label_left() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let mut resampler: Resampler<f64, TestSample> = Resampler::new(
         TimeDelta::seconds(5),
         ResamplingFunction::Average,
         1,
         start,
-        true,
+        Closed::Left,
+        Label::Left,
     );
     let step = TimeDelta::seconds(1);
     let data = vec![
@@ -733,7 +763,7 @@ fn test_first_timestamp_true() {
     let resampled = resampler.resample(start + step * 10);
     // Intervals: [0, 5) with samples t=0,1,2,3,4 → avg(1,2,3,4,5) = 3.0
     //            [5, 10) with samples t=5,6,7,8,9 → avg(6,7,8,9,10) = 8.0
-    // Output timestamp is at interval start (first_timestamp=true)
+    // Output timestamp is at interval start (label=Label::Left)
     assert_eq!(
         resampled,
         vec![
@@ -743,10 +773,10 @@ fn test_first_timestamp_true() {
     );
 }
 
-/// Test that first_timestamp only affects output timestamps, not aggregated values.
+/// Test that the label only affects output timestamps, not aggregated values.
 /// Both resamplers should produce the same values, just with different timestamps.
 #[test]
-fn test_first_timestamp_same_values() {
+fn test_label_same_values() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let step = TimeDelta::seconds(1);
     let data: Vec<TestSample> = (0..10)
@@ -758,14 +788,16 @@ fn test_first_timestamp_same_values() {
         ResamplingFunction::Average,
         1,
         start,
-        true,
+        Closed::Left,
+        Label::Left,
     );
     let mut resampler_false: Resampler<f64, TestSample> = Resampler::new(
         TimeDelta::seconds(5),
         ResamplingFunction::Average,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
 
     resampler_true.extend(data.clone());
@@ -788,10 +820,10 @@ fn test_first_timestamp_same_values() {
     }
 }
 
-/// Test that a sample exactly at interval boundary goes to the next interval.
-/// With [start, end) semantics, sample at t=5 should be in interval [5, 10), not [0, 5).
+/// Test that a sample exactly at interval boundary goes to the next interval
+/// for left-closed intervals.
 #[test]
-fn test_sample_at_interval_boundary() {
+fn test_sample_at_interval_boundary_closed_left() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let step = TimeDelta::seconds(1);
 
@@ -800,7 +832,8 @@ fn test_sample_at_interval_boundary() {
         ResamplingFunction::Sum,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
 
     // Only add samples at boundaries: t=0, t=5
@@ -824,6 +857,40 @@ fn test_sample_at_interval_boundary() {
     );
 }
 
+/// Test that a sample exactly at interval boundary stays in the current
+/// interval for right-closed intervals.
+#[test]
+fn test_sample_at_interval_boundary_closed_right() {
+    let start = DateTime::from_timestamp(0, 0).unwrap();
+    let step = TimeDelta::seconds(1);
+
+    let mut resampler: Resampler<f64, TestSample> = Resampler::new(
+        TimeDelta::seconds(5),
+        ResamplingFunction::Sum,
+        1,
+        start,
+        Closed::Right,
+        Label::Right,
+    );
+
+    let data = vec![
+        TestSample::new(start, Some(10.0)),
+        TestSample::new(start + step * 5, Some(20.0)),
+    ];
+
+    resampler.extend(data);
+
+    let resampled = resampler.resample(start + step * 10);
+
+    assert_eq!(
+        resampled,
+        vec![
+            TestSample::new(DateTime::from_timestamp(5, 0).unwrap(), Some(20.0)),
+            TestSample::new(DateTime::from_timestamp(10, 0).unwrap(), None),
+        ],
+    );
+}
+
 /// Test with data starting mid-interval.
 /// Verifies correct behavior when first sample doesn't align with interval start.
 #[test]
@@ -836,7 +903,8 @@ fn test_data_starting_mid_interval() {
         ResamplingFunction::Average,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
 
     // Data starts at t=2, not t=0
@@ -865,17 +933,18 @@ fn test_data_starting_mid_interval() {
 }
 
 /// Test that matches the README example exactly.
-/// This test verifies that first_timestamp only affects the output timestamp,
+/// This test verifies that the label only affects the output timestamp,
 /// not the interval grouping semantics.
 #[test]
-fn test_first_timestamp_false() {
+fn test_label_right() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let mut resampler: Resampler<f64, TestSample> = Resampler::new(
         TimeDelta::seconds(5),
         ResamplingFunction::Average,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     let data = vec![
@@ -894,11 +963,11 @@ fn test_first_timestamp_false() {
     resampler.extend(data);
 
     let resampled = resampler.resample(start + step * 10);
-    // Intervals should be the same as first_timestamp=true: [0, 5) and [5, 10)
+    // Intervals should be the same as label=Label::Left: [0, 5) and [5, 10)
     // Only the output timestamp should differ (end of interval instead of start)
     // Interval [0, 5) with samples t=0,1,2,3,4 → avg(1,2,3,4,5) = 3.0
     // Interval [5, 10) with samples t=5,6,7,8,9 → avg(6,7,8,9,10) = 8.0
-    // Output timestamp is at interval end (first_timestamp=false)
+    // Output timestamp is at interval end (label=Label::Right)
     assert_eq!(
         resampled,
         vec![
@@ -999,7 +1068,8 @@ fn test_resampling_non_primitive_average() {
         ResamplingFunction::Average,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     // Data starts at t=0
@@ -1041,7 +1111,8 @@ fn test_resampling_non_primitive_sum() {
         ResamplingFunction::Sum,
         1,
         start,
-        false,
+        Closed::Left,
+        Label::Right,
     );
     let step = TimeDelta::seconds(1);
     // Data starts at t=0
@@ -1099,7 +1170,8 @@ fn test_resample_function_basic() {
         &data,
         TimeDelta::seconds(5),
         ResamplingFunction::Average,
-        true,
+        Closed::Left,
+        Label::Left,
     );
 
     assert_eq!(result.len(), 2);
@@ -1114,7 +1186,7 @@ fn test_resample_function_basic() {
 }
 
 #[test]
-fn test_resample_function_first_timestamp_false() {
+fn test_resample_function_label_right() {
     let start = DateTime::from_timestamp(0, 0).unwrap();
     let step = TimeDelta::seconds(1);
 
@@ -1126,11 +1198,12 @@ fn test_resample_function_first_timestamp_false() {
         &data,
         TimeDelta::seconds(5),
         ResamplingFunction::Average,
-        false,
+        Closed::Left,
+        Label::Right,
     );
 
     assert_eq!(result.len(), 2);
-    // With first_timestamp=false, timestamps are at end of interval
+    // With label=Label::Right, timestamps are at end of interval
     assert_eq!(
         result[0],
         (DateTime::from_timestamp(5, 0).unwrap(), Some(3.0))
@@ -1149,7 +1222,8 @@ fn test_resample_function_empty_data() {
         &data,
         TimeDelta::seconds(5),
         ResamplingFunction::Average,
-        true,
+        Closed::Left,
+        Label::Left,
     );
 
     assert!(result.is_empty());
@@ -1176,7 +1250,8 @@ fn test_resample_function_with_none_values() {
         &data,
         TimeDelta::seconds(5),
         ResamplingFunction::Average,
-        true,
+        Closed::Left,
+        Label::Left,
     );
 
     assert_eq!(result.len(), 2);
@@ -1201,7 +1276,13 @@ fn test_resample_function_sum() {
         .map(|i| (start + step * i, Some((i + 1) as f64)))
         .collect();
 
-    let result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Sum, true);
+    let result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Sum,
+        Closed::Left,
+        Label::Left,
+    );
 
     assert_eq!(result.len(), 2);
     // Interval [0, 5): sum(1,2,3,4,5) = 15.0
@@ -1225,8 +1306,20 @@ fn test_resample_function_min_max() {
         .map(|i| (start + step * i, Some((i + 1) as f64)))
         .collect();
 
-    let min_result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Min, true);
-    let max_result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Max, true);
+    let min_result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Min,
+        Closed::Left,
+        Label::Left,
+    );
+    let max_result = resample(
+        &data,
+        TimeDelta::seconds(5),
+        ResamplingFunction::Max,
+        Closed::Left,
+        Label::Left,
+    );
 
     assert_eq!(
         min_result[0],
@@ -1256,7 +1349,8 @@ fn test_resample_function_single_sample() {
         &data,
         TimeDelta::seconds(5),
         ResamplingFunction::Average,
-        true,
+        Closed::Left,
+        Label::Left,
     );
 
     assert_eq!(result.len(), 1);

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -5,6 +5,9 @@
 
 import datetime as dt
 
+import pandas as pd
+import pytest
+
 from frequenz.resampling import Resampler, ResamplingFunction, resample
 
 
@@ -17,7 +20,8 @@ def test_resampler_resampling_function_average() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0 with values 1-10
@@ -45,7 +49,8 @@ def test_resampler_resampling_function_sum() -> None:
         ResamplingFunction.Sum,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0 with values 1-10
@@ -73,7 +78,8 @@ def test_resampler_resampling_function_max() -> None:
         ResamplingFunction.Max,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0 with values 1-10
@@ -101,7 +107,8 @@ def test_resampler_resampling_function_min() -> None:
         ResamplingFunction.Min,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0 with values 1-10
@@ -129,7 +136,8 @@ def test_resampler_resampling_function_first() -> None:
         ResamplingFunction.First,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0 with values 1-10
@@ -157,7 +165,8 @@ def test_resampler_resampling_function_last() -> None:
         ResamplingFunction.Last,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0 with values 1-10
@@ -185,7 +194,8 @@ def test_resampler_resampling_function_coalesce() -> None:
         ResamplingFunction.Coalesce,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0 with values 1-10, but t=5 is None
@@ -216,7 +226,8 @@ def test_resampler_resampling_function_count() -> None:
         ResamplingFunction.Count,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0 with values 1-10
@@ -244,7 +255,8 @@ def test_resampling_none() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # All values are None
@@ -332,8 +344,8 @@ def test_resampling_function_init() -> None:
     assert ResamplingFunction(7) == ResamplingFunction.Coalesce
 
 
-def test_resampler_first_timestamp() -> None:
-    """Test the resampler with the first timestamp."""
+def test_resampler_label_left() -> None:
+    """Test the resampler with the left interval label."""
     start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
     step = dt.timedelta(seconds=0.5)
     resampler = Resampler(
@@ -341,7 +353,8 @@ def test_resampler_first_timestamp() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=True,
+        closed="left",
+        label="left",
     )
 
     for i in range(0, 20):
@@ -358,7 +371,7 @@ def test_resampler_first_timestamp() -> None:
 
 
 def test_resampler_last_timestamp() -> None:
-    """Test the resampler with the last timestamp (first_timestamp=False)."""
+    """Test the resampler with the right interval label."""
     start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
     step = dt.timedelta(seconds=0.5)
     resampler = Resampler(
@@ -366,7 +379,8 @@ def test_resampler_last_timestamp() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
-        first_timestamp=False,
+        closed="left",
+        label="right",
     )
 
     # Data starts at t=0, step=0.5s, 20 samples
@@ -398,35 +412,162 @@ def test_resample_function_basic() -> None:
     # Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → avg = 8.0
     data = [(start + i * step, float(i + 1)) for i in range(10)]
 
-    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+    result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        closed="left",
+        label="left",
+    )
 
     assert len(result) == 2
     assert result[0] == (start, 3.0)
     assert result[1] == (start + 5 * step, 8.0)
 
 
-def test_resample_function_first_timestamp_false() -> None:
-    """Test the resample function with first_timestamp=False."""
+def test_resample_function_label_right() -> None:
+    """Test the resample function with label='right'."""
     start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
     step = dt.timedelta(seconds=1)
 
     data = [(start + i * step, float(i + 1)) for i in range(10)]
 
     result = resample(
-        data, dt.timedelta(seconds=5), ResamplingFunction.Average, first_timestamp=False
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        closed="left",
+        label="right",
     )
 
     assert len(result) == 2
-    # With first_timestamp=False, timestamps are at end of interval
+    # With label='right', timestamps are at end of interval
     assert result[0] == (start + 5 * step, 3.0)
     assert result[1] == (start + 10 * step, 8.0)
+
+
+def test_resample_function_closed_right() -> None:
+    """Test the resample function with right-closed intervals."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+    data = [
+        (start, 10.0),
+        (start + 5 * step, 20.0),
+    ]
+
+    result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Sum,
+        closed="right",
+        label="right",
+    )
+
+    assert result == [
+        (start + 5 * step, 20.0),
+        (start + 10 * step, None),
+    ]
+
+
+def test_resample_function_matches_pandas() -> None:
+    """Test the one-shot API against pandas with matching closed/label settings."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+    data = [(start + i * step, float(i + 1)) for i in range(10)]
+
+    result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        closed="left",
+        label="right",
+    )
+
+    pandas_series = pd.Series(
+        [value for _, value in data],
+        index=pd.DatetimeIndex([timestamp for timestamp, _ in data]),
+        dtype="float64",
+    )
+    pandas_result = pandas_series.resample("5s", closed="left", label="right").mean()
+    expected = [
+        (timestamp.to_pydatetime(), float(value))
+        for timestamp, value in pandas_result.items()
+    ]
+
+    assert result == expected
+
+
+def test_resample_function_invalid_label() -> None:
+    """Test the resample function rejects invalid labels."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    data = [(start, 1.0)]
+
+    with pytest.raises(ValueError, match="Invalid label"):
+        resample(
+            data,
+            dt.timedelta(seconds=5),
+            ResamplingFunction.Average,
+            closed="left",
+            label="middle",
+        )
+
+
+def test_resample_function_invalid_closed() -> None:
+    """Test the resample function rejects invalid closed values."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    data = [(start, 1.0)]
+
+    with pytest.raises(ValueError, match="Invalid closed"):
+        resample(
+            data,
+            dt.timedelta(seconds=5),
+            ResamplingFunction.Average,
+            closed="middle",
+            label="left",
+        )
+
+
+def test_resampler_invalid_label() -> None:
+    """Test the resampler rejects invalid labels."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+    with pytest.raises(ValueError, match="Invalid label"):
+        Resampler(
+            dt.timedelta(seconds=5),
+            ResamplingFunction.Average,
+            max_age_in_intervals=1,
+            start=start,
+            closed="left",
+            label="middle",
+        )
+
+
+def test_resampler_invalid_closed() -> None:
+    """Test the resampler rejects invalid closed values."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+    with pytest.raises(ValueError, match="Invalid closed"):
+        Resampler(
+            dt.timedelta(seconds=5),
+            ResamplingFunction.Average,
+            max_age_in_intervals=1,
+            start=start,
+            closed="middle",
+            label="left",
+        )
 
 
 def test_resample_function_empty_data() -> None:
     """Test the resample function with empty data."""
     data: list[tuple[dt.datetime, float | None]] = []
 
-    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+    result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        closed="left",
+        label="left",
+    )
 
     assert result == []
 
@@ -441,7 +582,13 @@ def test_resample_function_with_none_values() -> None:
         (start + i * step, None if i in (0, 5) else float(i + 1)) for i in range(10)
     ]
 
-    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+    result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        closed="left",
+        label="left",
+    )
 
     assert len(result) == 2
     # Interval [0, 5): values 2,3,4,5 → avg = 3.5
@@ -457,7 +604,13 @@ def test_resample_function_sum() -> None:
 
     data = [(start + i * step, float(i + 1)) for i in range(10)]
 
-    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Sum)
+    result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Sum,
+        closed="left",
+        label="left",
+    )
 
     assert len(result) == 2
     # Interval [0, 5): sum(1,2,3,4,5) = 15.0
@@ -473,8 +626,20 @@ def test_resample_function_min_max() -> None:
 
     data = [(start + i * step, float(i + 1)) for i in range(10)]
 
-    min_result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Min)
-    max_result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Max)
+    min_result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Min,
+        closed="left",
+        label="left",
+    )
+    max_result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Max,
+        closed="left",
+        label="left",
+    )
 
     assert min_result[0] == (start, 1.0)
     assert min_result[1] == (start + 5 * step, 6.0)
@@ -488,7 +653,13 @@ def test_resample_function_single_sample() -> None:
 
     data = [(start, 42.0)]
 
-    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+    result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        closed="left",
+        label="left",
+    )
 
     assert len(result) == 1
     assert result[0] == (start, 42.0)
@@ -512,6 +683,12 @@ def test_resample_function_all_methods() -> None:
         ResamplingFunction.Count,
         ResamplingFunction.Coalesce,
     ]:
-        result = resample(data, dt.timedelta(seconds=5), method)
+        result = resample(
+            data,
+            dt.timedelta(seconds=5),
+            method,
+            closed="left",
+            label="left",
+        )
         assert len(result) == 1
         assert result[0][0] == start

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -20,8 +20,11 @@ def test_resampler_resampling_function_average() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
-        resampler.push_sample(timestamp=start + i * step, value=i)
+    # Data starts at t=0 with values 1-10
+    # Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → avg = 3.0
+    # Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → avg = 8.0
+    for i in range(10):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 5 * step, 3.0),
@@ -45,8 +48,11 @@ def test_resampler_resampling_function_sum() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
-        resampler.push_sample(timestamp=start + i * step, value=i)
+    # Data starts at t=0 with values 1-10
+    # Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → sum = 15.0
+    # Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → sum = 40.0
+    for i in range(10):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 5 * step, 15.0),
@@ -70,8 +76,11 @@ def test_resampler_resampling_function_max() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
-        resampler.push_sample(timestamp=start + i * step, value=i)
+    # Data starts at t=0 with values 1-10
+    # Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → max = 5.0
+    # Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → max = 10.0
+    for i in range(10):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 5 * step, 5.0),
@@ -95,8 +104,11 @@ def test_resampler_resampling_function_min() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
-        resampler.push_sample(timestamp=start + i * step, value=i)
+    # Data starts at t=0 with values 1-10
+    # Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → min = 1.0
+    # Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → min = 6.0
+    for i in range(10):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 5 * step, 1.0),
@@ -120,8 +132,11 @@ def test_resampler_resampling_function_first() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
-        resampler.push_sample(timestamp=start + i * step, value=i)
+    # Data starts at t=0 with values 1-10
+    # Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → first = 1.0
+    # Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → first = 6.0
+    for i in range(10):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 5 * step, 1.0),
@@ -145,8 +160,11 @@ def test_resampler_resampling_function_last() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
-        resampler.push_sample(timestamp=start + i * step, value=i)
+    # Data starts at t=0 with values 1-10
+    # Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → last = 5.0
+    # Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → last = 10.0
+    for i in range(10):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 5 * step, 5.0),
@@ -170,11 +188,14 @@ def test_resampler_resampling_function_coalesce() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
-        if i == 6:
+    # Data starts at t=0 with values 1-10, but t=5 is None
+    # Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → coalesce = 1.0
+    # Interval [5, 10): t=5,6,7,8,9 with values None,7,8,9,10 → coalesce = 7.0
+    for i in range(10):
+        if i == 5:
             resampler.push_sample(timestamp=start + i * step, value=None)
         else:
-            resampler.push_sample(timestamp=start + i * step, value=i)
+            resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 5 * step, 1.0),
@@ -198,8 +219,11 @@ def test_resampler_resampling_function_count() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
-        resampler.push_sample(timestamp=start + i * step, value=i)
+    # Data starts at t=0 with values 1-10
+    # Interval [0, 5): t=0,1,2,3,4 → count = 5.0
+    # Interval [5, 10): t=5,6,7,8,9 → count = 5.0
+    for i in range(10):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 5 * step, 5.0),
@@ -223,7 +247,8 @@ def test_resampling_none() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 11):
+    # All values are None
+    for i in range(10):
         resampler.push_sample(timestamp=start + i * step, value=None)
 
     expected = [
@@ -333,7 +358,7 @@ def test_resampler_first_timestamp() -> None:
 
 
 def test_resampler_last_timestamp() -> None:
-    """Test the resampler with the last timestamp."""
+    """Test the resampler with the last timestamp (first_timestamp=False)."""
     start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
     step = dt.timedelta(seconds=0.5)
     resampler = Resampler(
@@ -344,8 +369,11 @@ def test_resampler_last_timestamp() -> None:
         first_timestamp=False,
     )
 
-    for i in range(1, 21):
-        resampler.push_sample(timestamp=start + i * step, value=i)
+    # Data starts at t=0, step=0.5s, 20 samples
+    # Interval [0, 5): t=0,0.5,1,1.5,2,2.5,3,3.5,4,4.5 → values 1-10 → avg = 5.5
+    # Interval [5, 10): t=5,5.5,6,6.5,7,7.5,8,8.5,9,9.5 → values 11-20 → avg = 15.5
+    for i in range(20):
+        resampler.push_sample(timestamp=start + i * step, value=i + 1)
 
     expected = [
         (start + 10 * step, 5.5),

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -5,7 +5,7 @@
 
 import datetime as dt
 
-from frequenz.resampling import Resampler, ResamplingFunction
+from frequenz.resampling import Resampler, ResamplingFunction, resample
 
 
 def test_resampler_resampling_function_average() -> None:
@@ -383,3 +383,135 @@ def test_resampler_last_timestamp() -> None:
     resampled = resampler.resample(start + 20 * step)
 
     assert resampled == expected
+
+
+# Tests for the one-shot resample function
+
+
+def test_resample_function_basic() -> None:
+    """Test the resample function with basic usage."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+
+    # Data: t=0,1,2,3,4,5,6,7,8,9 with values 1-10
+    # Interval [0, 5): t=0,1,2,3,4 with values 1,2,3,4,5 → avg = 3.0
+    # Interval [5, 10): t=5,6,7,8,9 with values 6,7,8,9,10 → avg = 8.0
+    data = [(start + i * step, float(i + 1)) for i in range(10)]
+
+    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+
+    assert len(result) == 2
+    assert result[0] == (start, 3.0)
+    assert result[1] == (start + 5 * step, 8.0)
+
+
+def test_resample_function_first_timestamp_false() -> None:
+    """Test the resample function with first_timestamp=False."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+
+    data = [(start + i * step, float(i + 1)) for i in range(10)]
+
+    result = resample(
+        data, dt.timedelta(seconds=5), ResamplingFunction.Average, first_timestamp=False
+    )
+
+    assert len(result) == 2
+    # With first_timestamp=False, timestamps are at end of interval
+    assert result[0] == (start + 5 * step, 3.0)
+    assert result[1] == (start + 10 * step, 8.0)
+
+
+def test_resample_function_empty_data() -> None:
+    """Test the resample function with empty data."""
+    data: list[tuple[dt.datetime, float | None]] = []
+
+    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+
+    assert result == []
+
+
+def test_resample_function_with_none_values() -> None:
+    """Test the resample function with None values."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+
+    # First value in each interval is None
+    data: list[tuple[dt.datetime, float | None]] = [
+        (start + i * step, None if i in (0, 5) else float(i + 1)) for i in range(10)
+    ]
+
+    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+
+    assert len(result) == 2
+    # Interval [0, 5): values 2,3,4,5 → avg = 3.5
+    # Interval [5, 10): values 7,8,9,10 → avg = 8.5
+    assert result[0] == (start, 3.5)
+    assert result[1] == (start + 5 * step, 8.5)
+
+
+def test_resample_function_sum() -> None:
+    """Test the resample function with Sum method."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+
+    data = [(start + i * step, float(i + 1)) for i in range(10)]
+
+    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Sum)
+
+    assert len(result) == 2
+    # Interval [0, 5): sum(1,2,3,4,5) = 15.0
+    # Interval [5, 10): sum(6,7,8,9,10) = 40.0
+    assert result[0] == (start, 15.0)
+    assert result[1] == (start + 5 * step, 40.0)
+
+
+def test_resample_function_min_max() -> None:
+    """Test the resample function with Min and Max methods."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+
+    data = [(start + i * step, float(i + 1)) for i in range(10)]
+
+    min_result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Min)
+    max_result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Max)
+
+    assert min_result[0] == (start, 1.0)
+    assert min_result[1] == (start + 5 * step, 6.0)
+    assert max_result[0] == (start, 5.0)
+    assert max_result[1] == (start + 5 * step, 10.0)
+
+
+def test_resample_function_single_sample() -> None:
+    """Test the resample function with a single sample."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+
+    data = [(start, 42.0)]
+
+    result = resample(data, dt.timedelta(seconds=5), ResamplingFunction.Average)
+
+    assert len(result) == 1
+    assert result[0] == (start, 42.0)
+
+
+def test_resample_function_all_methods() -> None:
+    """Test the resample function with all resampling methods."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+
+    data = [(start + i * step, float(i + 1)) for i in range(5)]
+
+    # Test all methods work without errors
+    for method in [
+        ResamplingFunction.Average,
+        ResamplingFunction.Sum,
+        ResamplingFunction.Min,
+        ResamplingFunction.Max,
+        ResamplingFunction.First,
+        ResamplingFunction.Last,
+        ResamplingFunction.Count,
+        ResamplingFunction.Coalesce,
+    ]:
+        result = resample(data, dt.timedelta(seconds=5), method)
+        assert len(result) == 1
+        assert result[0][0] == start

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -4,11 +4,11 @@
 """Tests to verify that the resampler can be used successfully from Python."""
 
 import datetime as dt
+from typing import Literal
 
 import pandas as pd
 import pytest
-
-from frequenz.resampling import Resampler, ResamplingFunction, resample
+from frequenz.resampling import Closed, Label, Resampler, ResamplingFunction, resample
 
 
 def test_resampler_resampling_function_average() -> None:
@@ -20,8 +20,8 @@ def test_resampler_resampling_function_average() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0 with values 1-10
@@ -49,8 +49,8 @@ def test_resampler_resampling_function_sum() -> None:
         ResamplingFunction.Sum,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0 with values 1-10
@@ -78,8 +78,8 @@ def test_resampler_resampling_function_max() -> None:
         ResamplingFunction.Max,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0 with values 1-10
@@ -107,8 +107,8 @@ def test_resampler_resampling_function_min() -> None:
         ResamplingFunction.Min,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0 with values 1-10
@@ -136,8 +136,8 @@ def test_resampler_resampling_function_first() -> None:
         ResamplingFunction.First,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0 with values 1-10
@@ -165,8 +165,8 @@ def test_resampler_resampling_function_last() -> None:
         ResamplingFunction.Last,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0 with values 1-10
@@ -194,8 +194,8 @@ def test_resampler_resampling_function_coalesce() -> None:
         ResamplingFunction.Coalesce,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0 with values 1-10, but t=5 is None
@@ -226,8 +226,8 @@ def test_resampler_resampling_function_count() -> None:
         ResamplingFunction.Count,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0 with values 1-10
@@ -255,8 +255,8 @@ def test_resampling_none() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # All values are None
@@ -353,8 +353,8 @@ def test_resampler_label_left() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="left",
+        closed=Closed.Left,
+        label=Label.Left,
     )
 
     for i in range(0, 20):
@@ -379,8 +379,8 @@ def test_resampler_last_timestamp() -> None:
         ResamplingFunction.Average,
         max_age_in_intervals=1,
         start=start,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     # Data starts at t=0, step=0.5s, 20 samples
@@ -416,8 +416,8 @@ def test_resample_function_basic() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Average,
-        closed="left",
-        label="left",
+        closed=Closed.Left,
+        label=Label.Left,
     )
 
     assert len(result) == 2
@@ -436,8 +436,8 @@ def test_resample_function_label_right() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Average,
-        closed="left",
-        label="right",
+        closed=Closed.Left,
+        label=Label.Right,
     )
 
     assert len(result) == 2
@@ -459,17 +459,31 @@ def test_resample_function_closed_right() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Sum,
-        closed="right",
-        label="right",
+        closed=Closed.Right,
+        label=Label.Right,
     )
 
     assert result == [
+        (start, 10.0),
         (start + 5 * step, 20.0),
-        (start + 10 * step, None),
     ]
 
 
-def test_resample_function_matches_pandas() -> None:
+@pytest.mark.parametrize(
+    ("closed", "label", "pandas_closed", "pandas_label"),
+    [
+        (Closed.Left, Label.Left, "left", "left"),
+        (Closed.Left, Label.Right, "left", "right"),
+        (Closed.Right, Label.Left, "right", "left"),
+        (Closed.Right, Label.Right, "right", "right"),
+    ],
+)
+def test_resample_function_matches_pandas(
+    closed: Closed,
+    label: Label,
+    pandas_closed: Literal["left", "right"],
+    pandas_label: Literal["left", "right"],
+) -> None:
     """Test the one-shot API against pandas with matching closed/label settings."""
     start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
     step = dt.timedelta(seconds=1)
@@ -479,8 +493,8 @@ def test_resample_function_matches_pandas() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Average,
-        closed="left",
-        label="right",
+        closed=closed,
+        label=label,
     )
 
     pandas_series = pd.Series(
@@ -488,73 +502,41 @@ def test_resample_function_matches_pandas() -> None:
         index=pd.DatetimeIndex([timestamp for timestamp, _ in data]),
         dtype="float64",
     )
-    pandas_result = pandas_series.resample("5s", closed="left", label="right").mean()
+    pandas_result = pandas_series.resample(
+        "5s", closed=pandas_closed, label=pandas_label
+    ).mean()
     expected = [
         (timestamp.to_pydatetime(), float(value))
-        for timestamp, value in pandas_result.items()
+        for timestamp, value in zip(
+            pandas_result.index, pandas_result.to_list(), strict=True
+        )
     ]
 
     assert result == expected
 
 
-def test_resample_function_invalid_label() -> None:
-    """Test the resample function rejects invalid labels."""
-    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
-    data = [(start, 1.0)]
-
+def test_label_init_invalid_value() -> None:
+    """Test the Label enum rejects invalid values."""
     with pytest.raises(ValueError, match="Invalid label"):
-        resample(
-            data,
-            dt.timedelta(seconds=5),
-            ResamplingFunction.Average,
-            closed="left",
-            label="middle",
-        )
+        Label(99)
 
 
-def test_resample_function_invalid_closed() -> None:
-    """Test the resample function rejects invalid closed values."""
-    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
-    data = [(start, 1.0)]
-
+def test_closed_init_invalid_value() -> None:
+    """Test the Closed enum rejects invalid values."""
     with pytest.raises(ValueError, match="Invalid closed"):
-        resample(
-            data,
-            dt.timedelta(seconds=5),
-            ResamplingFunction.Average,
-            closed="middle",
-            label="left",
-        )
+        Closed(99)
 
 
-def test_resampler_invalid_label() -> None:
-    """Test the resampler rejects invalid labels."""
-    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
-
-    with pytest.raises(ValueError, match="Invalid label"):
-        Resampler(
-            dt.timedelta(seconds=5),
-            ResamplingFunction.Average,
-            max_age_in_intervals=1,
-            start=start,
-            closed="left",
-            label="middle",
-        )
+def test_label_values_members() -> None:
+    """Test the Label enum helpers."""
+    assert Label.values() == [0, 1]
+    assert Label.members() == [("Left", 0), ("Right", 1)]
 
 
-def test_resampler_invalid_closed() -> None:
-    """Test the resampler rejects invalid closed values."""
-    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
-
-    with pytest.raises(ValueError, match="Invalid closed"):
-        Resampler(
-            dt.timedelta(seconds=5),
-            ResamplingFunction.Average,
-            max_age_in_intervals=1,
-            start=start,
-            closed="middle",
-            label="left",
-        )
+def test_closed_values_members() -> None:
+    """Test the Closed enum helpers."""
+    assert Closed.values() == [0, 1]
+    assert Closed.members() == [("Left", 0), ("Right", 1)]
 
 
 def test_resample_function_empty_data() -> None:
@@ -565,8 +547,8 @@ def test_resample_function_empty_data() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Average,
-        closed="left",
-        label="left",
+        closed=Closed.Left,
+        label=Label.Left,
     )
 
     assert result == []
@@ -586,8 +568,8 @@ def test_resample_function_with_none_values() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Average,
-        closed="left",
-        label="left",
+        closed=Closed.Left,
+        label=Label.Left,
     )
 
     assert len(result) == 2
@@ -595,6 +577,28 @@ def test_resample_function_with_none_values() -> None:
     # Interval [5, 10): values 7,8,9,10 → avg = 8.5
     assert result[0] == (start, 3.5)
     assert result[1] == (start + 5 * step, 8.5)
+
+
+def test_resample_function_interval_with_only_none() -> None:
+    """Test a bucket that contains only None values."""
+    start = dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(seconds=1)
+
+    data: list[tuple[dt.datetime, float | None]] = [
+        (start + i * step, None if i < 5 else float(i + 1)) for i in range(10)
+    ]
+
+    result = resample(
+        data,
+        dt.timedelta(seconds=5),
+        ResamplingFunction.Average,
+        closed=Closed.Left,
+        label=Label.Left,
+    )
+
+    assert len(result) == 2
+    assert result[0] == (start, None)
+    assert result[1] == (start + 5 * step, 8.0)
 
 
 def test_resample_function_sum() -> None:
@@ -608,8 +612,8 @@ def test_resample_function_sum() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Sum,
-        closed="left",
-        label="left",
+        closed=Closed.Left,
+        label=Label.Left,
     )
 
     assert len(result) == 2
@@ -630,15 +634,15 @@ def test_resample_function_min_max() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Min,
-        closed="left",
-        label="left",
+        closed=Closed.Left,
+        label=Label.Left,
     )
     max_result = resample(
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Max,
-        closed="left",
-        label="left",
+        closed=Closed.Left,
+        label=Label.Left,
     )
 
     assert min_result[0] == (start, 1.0)
@@ -657,8 +661,8 @@ def test_resample_function_single_sample() -> None:
         data,
         dt.timedelta(seconds=5),
         ResamplingFunction.Average,
-        closed="left",
-        label="left",
+        closed=Closed.Left,
+        label=Label.Left,
     )
 
     assert len(result) == 1
@@ -687,8 +691,8 @@ def test_resample_function_all_methods() -> None:
             data,
             dt.timedelta(seconds=5),
             method,
-            closed="left",
-            label="left",
+            closed=Closed.Left,
+            label=Label.Left,
         )
         assert len(result) == 1
         assert result[0][0] == start


### PR DESCRIPTION
## Summary

Add a new `resample()` convenience function available in both Rust and Python APIs, allowing users to resample data in a single call without needing to instantiate and manage a `Resampler` instance.

### Rust API
```rust
use frequenz_resampling::{resample, ResamplingFunction, SimpleSample};
let result = resample(&data, TimeDelta::seconds(5), ResamplingFunction::Average, true);
```

### Python API
```python
from frequenz.resampling import resample, ResamplingFunction
result = resample(data, timedelta(seconds=5), ResamplingFunction.Average)
```

## Changes

- Added `resample()` function in Rust (`src/lib.rs`) with `SimpleSample` type
- Added `resample()` Python binding (`src/python.rs`)
- Made `epoch_align()` public to support the new functionality
- Updated README with "One-Shot Resampling" and "Stateful Resampling" sections
- Updated type stubs with `Sequence` input type for flexibility
- Added comprehensive test coverage in both Rust and Python
- Updated RELEASE_NOTES.md

depends on #75 